### PR TITLE
Adds API for automation modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,19 @@ Project designed and written in Python in conjunction with the D7017E Project in
 The purpose of the project is to implement a system where the user can write instrutions in clear text using machine learning and natural language processing, in order to instruct the computer what to do. 
 
 ## Requirements
-Python 3.8.5
+* Python 3.8.5
+* Anaconda
 
 ## Setup
+Create conda environment to handle dependencies.
+
+    conda env create -f substorm-nlp.yml
+    conda activate substorm-nlp
 
 ### Python
+Add user information to `lib/settings.py`.
+
+Example on how to use the automation module is in `demo.py`
 
 ### Linux
 Below are the absolute minimum packages you will need for Linux. Names might vary depending on your distribution, you might need to install it manually if you can't find it using your distribution's package manager.

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,17 @@
+import sys
+
+from lib import Error
+from lib.automate import Automate
+
+automate = Automate()
+try:
+    response = automate.run(
+        "skikko",
+        ["aron@antarkt.is"],
+        None,
+        "test\n\ndet är ett test",
+        "Aron Widforss"
+    )
+    print(response)
+except Error as err:
+    print(err, file=sys.stdout)

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,5 @@
+class Error(Exception):
+    pass
+
+class NotImplementedError(Error):
+    pass

--- a/lib/automate/__init__.py
+++ b/lib/automate/__init__.py
@@ -1,0 +1,75 @@
+from fuzzywuzzy import process as fuzzy
+from importlib import import_module
+
+from lib import Error
+from lib.settings import SETTINGS
+
+
+class Automate:
+    def __init__(self):
+        """ Register new modules here """
+        self.modules = [
+            import_module("lib.automate.modules.send").Send,
+        ]
+        self.verbs = {}
+        for module in self.modules:
+            for verb in module.verbs:
+                self.verbs[verb] = module
+
+    def get_verbs(self):
+        """
+        :return: A list of keywords for the registered automation modules.
+        :rtype: list[string]
+        """
+        return list(self.verbs.keys())
+
+    def get_senders(self):
+        """
+        :return: A list of names of users listed in the SETTINGS.
+        :rtype: list[string]
+        """
+        return list(SETTINGS["users"].keys())
+
+    def run(self, module_name, to, when, body, sender):
+        """
+        Run automation on registered module.
+        :param module_name: Something close to a keyword of a automation module.
+                            This is handled via fuzzy search.
+        :type module_name: string
+        :param to: Intended recipients. Should be fuzzy in the future.
+        :type to: list[string]
+        :param when: When the command should be executed. Not currently used.
+        :type when: datetime.datetime
+        :param body: A body text of the task, if relevant.
+        :type body: string
+        :param sender: Who is sending this. Fuzzy match against SETTINGS[users].keys().
+        :type sender: string
+        :return: Response from automation module.
+        :rtype: string
+        """
+        def handle_response(success, response):
+            if response:
+                print(response, end=": ", flush=True)
+                return handle_response(*instance.followup(input()))
+            elif success:
+                return success
+            else:
+                raise NoResponseError("No response from automation module")
+
+        if module_name in self.verbs:
+            instance = self.verbs[module_name]()
+        else:
+            fuzzy_match, score = fuzzy.extractOne(module_name, self.get_verbs())
+            if score > 30:
+                instance = self.verbs[fuzzy_match]()
+            else:
+                raise AutomationNotFoundError("Automation module not found")
+        return handle_response(*instance.run(to, when, body, sender))
+
+
+class NoResponseError(Error):
+    pass
+
+
+class AutomationNotFoundError(Error):
+    pass

--- a/lib/automate/modules/__init__.py
+++ b/lib/automate/modules/__init__.py
@@ -1,0 +1,11 @@
+class Module:
+    verbs = []
+
+    def __init__(self):
+        pass
+
+    def run(self, to, when, body, sender):
+        raise NotImplementedError("Method not implemented")
+
+    def followup(self, answer):
+        raise NotImplementedError("Method not implemented")

--- a/lib/automate/modules/send.py
+++ b/lib/automate/modules/send.py
@@ -1,0 +1,41 @@
+from fuzzywuzzy import process as fuzzy
+from email.message import EmailMessage
+import smtplib
+
+from lib.automate.modules import Module
+from lib.settings import SETTINGS
+
+
+class Send(Module):
+    verbs = ["skicka", "maila", "mejla", "eposta", "e-posta"]
+
+    def __init__(self):
+        super(Send, self).__init__()
+
+    def run(self, to, when, body, sender):
+        user, _ = fuzzy.extractOne(sender, SETTINGS["users"].keys())
+        settings = SETTINGS["users"][user]["email"]
+        content = body + f"\n\nVänligen,\n{user}"
+
+        msg = EmailMessage()
+        msg["Subject"] = body.partition("\n")[0]
+        msg["From"] = settings["address"]
+        msg["To"] = ", ".join(to)
+        msg.set_content(content)
+
+        ssl_type = f"SMTP{'_SSL' if settings['ssl'] else ''}"
+        smtp = getattr(smtplib, ssl_type)(
+            host=settings["host"],
+            port=settings["port"]
+        )
+        smtp.login(settings["username"], settings["password"])
+        smtp.send_message(msg)
+        smtp.quit()
+
+        response = f"Skickade epost:\n"\
+            + f"Från: {settings['address']}\n"\
+            + f"Till: {msg['To']}\n"\
+            + f"Ämne: {msg['Subject']}\n"\
+            + f"Meddelande: {content}"
+
+        return response, None

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -1,0 +1,15 @@
+SETTINGS = {
+    # Add your user here
+    "users": {
+        "Aron Widforss": {
+            "email": {
+                "address": "aron@antarkt.is",
+                "username": "aronwidforss@fastmail.com",
+                "password": "password",
+                "ssl": True,
+                "host": "smtp.fastmail.com",
+                "port": 465
+            }
+        }
+    }
+}

--- a/substorm-nlp.yml
+++ b/substorm-nlp.yml
@@ -1,0 +1,28 @@
+name: substorm-nlp
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1=main
+  - ca-certificates=2020.6.20=hecda079_0
+  - certifi=2020.6.20=py38h32f6830_0
+  - fuzzywuzzy=0.17.0=py_0
+  - ld_impl_linux-64=2.33.1=h53a641e_7
+  - libedit=3.1.20191231=h14c3975_1
+  - libffi=3.3=he6710b0_2
+  - libgcc-ng=9.1.0=hdf63c60_0
+  - libstdcxx-ng=9.1.0=hdf63c60_0
+  - ncurses=6.2=he6710b0_1
+  - openssl=1.1.1h=h516909a_0
+  - pip=20.2.2=py38_0
+  - python=3.8.5=h7579374_1
+  - python-levenshtein=0.12.0=py38h1e0a361_1001
+  - python_abi=3.8=1_cp38
+  - readline=8.0=h7b6447c_0
+  - setuptools=49.6.0=py38_0
+  - sqlite=3.33.0=h62c20be_0
+  - tk=8.6.10=hbc83047_0
+  - wheel=0.35.1=py_0
+  - xz=5.2.5=h7b6447c_0
+  - zlib=1.2.11=h7b6447c_3
+prefix: /home/aron/anaconda3/envs/substorm-nlp


### PR DESCRIPTION
Modules are listed inside lib/automate/modules. Modules are
required to have the attribute self.verbs and the methods
self.run(self, to, when, body, sender) as well as
self.followup(self, answer). An example module is shown in
lib/automate/modules/send.py, which sends a mail given the
parameters.

The when-parameter is currently ignored, but should
in the future be a datetime.datetime object which defines when the
command should be executed.

The example does not use the self.followup(self, answer). The
intended use of this is to ask extra questions if something in
the original call was unclear.