### PR TITLE
Add simple NLP for sending emails

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -2,16 +2,15 @@ import sys
 
 from lib import Error
 from lib.automate import Automate
+from lib.nlp import nlp
 
 automate = Automate()
+n = nlp.NLP()
+
+# Enable the SMTP server before running the following
 try:
-    response = automate.run(
-        "skikko",
-        ["aron@antarkt.is"],
-        None,
-        "test\n\ndet är ett test",
-        "Aron Widforss"
-    )
+    text = "send an email with the content 'hello world' to substorm@email.com"
+    response = n.run(text)
     print(response)
 except Error as err:
     print(err, file=sys.stdout)

--- a/lib/automate/modules/send.py
+++ b/lib/automate/modules/send.py
@@ -7,7 +7,7 @@ from lib.settings import SETTINGS
 
 
 class Send(Module):
-    verbs = ["skicka", "maila", "mejla", "eposta", "e-posta"]
+    verbs = ["skicka", "maila", "mejla", "eposta", "e-posta", "send"]
 
     def __init__(self):
         super(Send, self).__init__()

--- a/lib/cli/commands.py
+++ b/lib/cli/commands.py
@@ -9,36 +9,20 @@ sys.path.append(".")
 
 from lib import Error
 from lib.automate import Automate
-
+from lib.nlp import nlp
 
 def commands(arr):
     """
     Commands supported by the CLI
     """
-    if arr[0] == "send" or arr[0] == "s":
-        # TODO: send arr[1] to automation
-        print("text = ", arr[1:])
-        arr.clear()
-    elif arr[0] == "exit" or arr[0] == "e":
+    if arr[0] == "exit" or arr[0] == "e":
         sys.exit()
     elif arr[0] == "help" or arr[0] == "h":
         prompt()
     else:
-        # Try to let the automation decide what module to invoke depending on
-        # the first word the user entered
-        automate = Automate()
-        try:
-            response = automate.run(
-                arr[0],
-                ["substorm@email.com"],
-                None,
-                "Hello,\nThis message was sent automatically",
-                "John Doe",
-            )
-            print(response)
-        except Error as err:
-            print(err)
-
+        listToStr = ' '.join(map(str, arr)) 
+        n = nlp.NLP()
+        n.run(listToStr)
 
 def prompt():
     dirname = os.path.dirname(__file__)

--- a/lib/nlp/nlp.py
+++ b/lib/nlp/nlp.py
@@ -1,34 +1,27 @@
 import spacy
 import re
-import sys
 
 from spacy.matcher import Matcher
 from lib.automate import Automate
 from lib import Error
+
 
 class NLP:
     def __init__(self):
         self.nlp = spacy.load("en_core_web_lg")
 
     def getBodyBetweenQuotations(self, doc):
-        matches=re.findall(r'\'(.+?)\'', doc)
+        matches = re.findall(r"\'(.+?)\'", doc)
         return ",".join(matches)
 
     def sendAutomate(self, verb, recipients, when, body, sender):
         automate = Automate()
         try:
-            response = automate.run(
-                verb,
-                recipients,
-                when,
-                body,
-                sender,
-            )
+            response = automate.run(verb, recipients, when, body, sender,)
             return response
         except Error as err:
             return err
 
-    
     def run(self, text):
         """
         Start NLP on the given text. Takes a few seconds to process if your 
@@ -43,10 +36,10 @@ class NLP:
         doc = self.nlp(text)
 
         # Match patterns VERBS, EMAIL
-        matcher = Matcher(self.nlp.vocab)    
-        mail_pattern = [{"POS":"VERB"}] 
+        matcher = Matcher(self.nlp.vocab)
+        mail_pattern = [{"POS": "VERB"}]
         to_pattern = [{"LIKE_EMAIL": True}]
-        
+
         matcher.add("MAIL_PATTERN", None, mail_pattern)
         mail_matches = matcher(doc)
         matcher.remove("MAIL_PATTERN")
@@ -62,9 +55,9 @@ class NLP:
             similarity = verb.similarity(send)
             if similarity > 0.8:
                 body = self.getBodyBetweenQuotations(text)
-                response = self.sendAutomate(verb.text, recipients, None, body, "John Doe") 
+                response = self.sendAutomate(
+                    verb.text, recipients, None, body, "John Doe"
+                )
                 return response
 
         print("I did not understand")
-
-

--- a/lib/nlp/nlp.py
+++ b/lib/nlp/nlp.py
@@ -1,0 +1,70 @@
+import spacy
+import re
+import sys
+
+from spacy.matcher import Matcher
+from lib.automate import Automate
+from lib import Error
+
+class NLP:
+    def __init__(self):
+        self.nlp = spacy.load("en_core_web_lg")
+
+    def getBodyBetweenQuotations(self, doc):
+        matches=re.findall(r'\'(.+?)\'', doc)
+        return ",".join(matches)
+
+    def sendAutomate(self, verb, recipients, when, body, sender):
+        automate = Automate()
+        try:
+            response = automate.run(
+                verb,
+                recipients,
+                when,
+                body,
+                sender,
+            )
+            return response
+        except Error as err:
+            return err
+
+    
+    def run(self, text):
+        """
+        Start NLP on the given text. Takes a few seconds to process if your 
+        computer is slow.
+        :param text: The user NL input to process
+        :type text: string
+        """
+        # Currently only supports mail, only looks for synonyms of "send"
+        send = self.nlp("send")
+        send = send[0]
+
+        doc = self.nlp(text)
+
+        # Match patterns VERBS, EMAIL
+        matcher = Matcher(self.nlp.vocab)    
+        mail_pattern = [{"POS":"VERB"}] 
+        to_pattern = [{"LIKE_EMAIL": True}]
+        
+        matcher.add("MAIL_PATTERN", None, mail_pattern)
+        mail_matches = matcher(doc)
+        matcher.remove("MAIL_PATTERN")
+
+        matcher.add("TO_PATTERN", None, to_pattern)
+        to_matches = matcher(doc)
+
+        verbs = [doc[start:end] for match_id, start, end in mail_matches]
+        recipients = [doc[start:end].text for match_id, start, end in to_matches]
+
+        # Looks for any synonym to "send"
+        for verb in verbs:
+            similarity = verb.similarity(send)
+            if similarity > 0.8:
+                body = self.getBodyBetweenQuotations(text)
+                response = self.sendAutomate(verb.text, recipients, None, body, "John Doe") 
+                return response
+
+        print("I did not understand")
+
+


### PR DESCRIPTION
# Summary
This PR adds a simple NLP between the CLI and Automation which looks for synonyms to "send", a body of text within single quotation marks and any email addresses. It does not support sending emails to just a contact name, you will need to specify the addresses.

# Test
You can test it by starting the SMTP server
```
$ python -m smtpd -n -c DebuggingServer localhost:1025
```
then the CLI, type any sentence with "send" (or synonym) and at least one email. E.g:

```
$ python lib/cli/cli.py
please send an email with the content 'hello world' to substorm@email.com
...
```
Or just run 
```
$ python demo.py
```

# Other
Fixes #19 