### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug report
+about: Bug report template
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# Expected behavior
+
+# Actual behavior
+
+# Steps to reproduce
+1.
+2.
+3.
+
+# Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Feature request template
+title: ''
+labels: enhancement, feature
+assignees: ''
+
+---
+
+# Summary
+
+# Examples
+
+# Context

--- a/.github/ISSUE_TEMPLATE/pull-request-.md
+++ b/.github/ISSUE_TEMPLATE/pull-request-.md
@@ -1,0 +1,16 @@
+---
+name: 'Pull request '
+about: Pull request template
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Proposed changes
+*
+*
+*
+
+# Related issue
+Fixes #


### PR DESCRIPTION
Add issue templates for the project. Makes it easier to add issues etc. as they should show up whenever you add an issue or make a PR.