### PR TITLE
Add dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Create conda environment to handle dependencies.
     conda env create -f substorm-nlp.yml
     conda activate substorm-nlp
 
+### Dev dependencies
+
+If you are going to develop in this project some development dependencies will also be needed. These can be installed after the conda environment has been activated using
+
+```bash
+pip install -r requirements-dev.txt
+```
+
 ### Python
 
 Add user information to `lib/settings.py`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+black==19.10b0
+flake8==3.8.3
+pytest==6.0.2


### PR DESCRIPTION
The dev dependencies can now be installed after activating the conda env
using
```bash
pip install -r requirements-dev.txt

```
currently this install black, flake8 and pytest. We should extend `requirements-dev.txt` with dependencies only needed for development.