### PR TITLE
Move dev dependencies from pip to conda

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -22,9 +22,6 @@ jobs:
         run: |
           # $CONDA is an environment variable pointing to the root of the miniconda directory
           $CONDA/bin/conda env update --file substorm-nlp.yml --name base
-          $CONDA/bin/conda install -q black
-          $CONDA/bin/conda install -q flake8
-          $CONDA/bin/conda install -q pytest
       - name: Format using black
         run: |
           $CONDA/bin/black --check . --diff --line-length=80

--- a/README.md
+++ b/README.md
@@ -22,14 +22,6 @@ Download spaCy model.
 
     python -m spacy download en_core_web_lg
 
-### Dev dependencies
-
-If you are going to develop in this project some development dependencies will also be needed. These can be installed after the conda environment has been activated using
-
-```bash
-pip install -r requirements-dev.txt
-```
-
 ### Python
 
 Add user information to `lib/settings.py`.

--- a/lib/nlp/nlp.py
+++ b/lib/nlp/nlp.py
@@ -16,7 +16,7 @@ class NLP:
 
     def sendAutomate(self, verb, recipients, when, body, sender):
         automate = Automate()
-        return automate.run(verb, recipients, when, body, sender,)
+        return automate.run(verb, recipients, when, body, sender)
 
     def run(self, text):
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,0 @@
-black==19.10b0
-flake8==3.8.3
-pytest==6.0.2
-caldav==0.7.1

--- a/substorm-nlp.yml
+++ b/substorm-nlp.yml
@@ -4,21 +4,27 @@ channels:
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=main
+  - appdirs=1.4.3=py_1
   - attrs=20.2.0=py_0
+  - black=20.8b1=py_1
   - blas=1.0=mkl
   - brotlipy=0.7.0=py38h7b6447c_1000
-  - ca-certificates=2020.6.20=hecda079_0
+  - ca-certificates=2020.7.22=0
   - catalogue=1.0.0=py38_1
-  - certifi=2020.6.20=py38h32f6830_0
+  - certifi=2020.6.20=py38_0
   - cffi=1.14.3=py38he30daa8_0
   - chardet=3.0.4=py38_1003
+  - click=7.1.2=pyh9f0ad1d_0
   - cryptography=3.1.1=py38h1ba5d50_0
   - cymem=2.0.3=py38he6710b0_0
   - cython-blis=0.4.1=py38h7b6447c_1
+  - dataclasses=0.7=pyhb2cacf7_7
+  - flake8=3.8.4=py_0
   - fuzzywuzzy=0.17.0=py_0
   - idna=2.10=py_0
   - importlib-metadata=1.7.0=py38_0
   - importlib_metadata=1.7.0=0
+  - iniconfig=1.0.1=py_0
   - intel-openmp=2020.2=254
   - jsonschema=3.0.2=py38_0
   - ld_impl_linux-64=2.33.1=h53a641e_7
@@ -26,26 +32,38 @@ dependencies:
   - libffi=3.3=he6710b0_2
   - libgcc-ng=9.1.0=hdf63c60_0
   - libstdcxx-ng=9.1.0=hdf63c60_0
+  - mccabe=0.6.1=py38_1
   - mkl=2020.2=256
   - mkl-service=2.3.0=py38he904b0f_0
   - mkl_fft=1.2.0=py38h23d657b_0
   - mkl_random=1.1.1=py38h0573a6f_0
+  - more-itertools=8.5.0=py_0
   - murmurhash=1.0.2=py38he6710b0_0
+  - mypy_extensions=0.4.3=py38h32f6830_1
   - ncurses=6.2=he6710b0_1
   - numpy=1.19.1=py38hbc911f0_0
   - numpy-base=1.19.1=py38hfa32c7d_0
-  - openssl=1.1.1h=h516909a_0
+  - openssl=1.1.1h=h7b6447c_0
+  - packaging=20.4=py_0
+  - pathspec=0.8.0=pyh9f0ad1d_0
   - pip=20.2.2=py38_0
   - plac=0.9.6=py38_1
+  - pluggy=0.13.1=py38_0
   - preshed=3.0.2=py38he6710b0_1
+  - py=1.9.0=py_0
+  - pycodestyle=2.6.0=py_0
   - pycparser=2.20=py_2
+  - pyflakes=2.2.0=py_0
   - pyopenssl=19.1.0=py_1
+  - pyparsing=2.4.7=py_0
   - pyrsistent=0.17.3=py38h7b6447c_0
   - pysocks=1.7.1=py38_0
+  - pytest=6.1.0=py38_0
   - python=3.8.5=h7579374_1
   - python-levenshtein=0.12.0=py38h1e0a361_1001
   - python_abi=3.8=1_cp38
   - readline=8.0=h7b6447c_0
+  - regex=2020.9.27=py38h1e0a361_0
   - requests=2.24.0=py_0
   - setuptools=49.6.0=py38_0
   - six=1.15.0=py_0
@@ -55,11 +73,23 @@ dependencies:
   - srsly=1.0.2=py38he6710b0_0
   - thinc=7.4.1=py38hfd86e86_0
   - tk=8.6.10=hbc83047_0
+  - toml=0.10.1=pyh9f0ad1d_0
   - tqdm=4.49.0=py_0
+  - typed-ast=1.4.1=py38h516909a_0
+  - typing_extensions=3.7.4.2=py_0
   - urllib3=1.25.10=py_0
   - wasabi=0.8.0=py_0
   - wheel=0.35.1=py_0
   - xz=5.2.5=h7b6447c_0
   - zipp=3.1.0=py_0
   - zlib=1.2.11=h7b6447c_3
-prefix: /home/user/miniconda3/envs/substorm-nlp
+  - pip:
+    - caldav==0.7.1
+    - defusedxml==0.6.0
+    - lxml==4.5.2
+    - passlib==1.7.3
+    - python-dateutil==2.8.1
+    - radicale==3.0.6
+    - vobject==0.9.6.1
+prefix: /home/banunkers/anaconda3/envs/substorm-nlp
+


### PR DESCRIPTION
This pull-request reverts having to use pip install -r requirements-dev.txt to install the dev-dependencies.

All dependencies are now installed using conda. The main reason behind
this is that if you install a package using pip inside the conda env and
then you export it to the substorm-nlp.yml file the installed pip
dependencies will be added anyway.

Note that any Pip dependencies can be installed (and added to the env) using `pip install
<name>` and once you update the env file with `conda env export >
substorm-nlp.yml` the pip dependency will be added.

I also added radicale, which is used to start a local CalDav server, as a dependency so you don't have to install it manually when you want to try it locally.

Closes #46