### PR TITLE
Add pytest config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source =
+  ./lib

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Add user information to `lib/settings.py`.
 
 Example on how to use the automation module is in `demo.py`
 
+### Testing
+
+The tests can be run with the following command
+
+```bash
+pytest
+```
+
+while inside the project directory.
+
+A coverage report will automatically be generated and and saved in `htmlcov` and it can be viewed at `htmlcov/index.html`
+
 #### Local SMTP server
 
 It can be nice to test the Send automation module (sends emails) using a local SMTP debugging server. This can be done by running

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -vv --cov --cov-branch --cov-report html:htmlcov

--- a/substorm-nlp.yml
+++ b/substorm-nlp.yml
@@ -58,7 +58,6 @@ dependencies:
   - pyparsing=2.4.7=py_0
   - pyrsistent=0.17.3=py38h7b6447c_0
   - pysocks=1.7.1=py38_0
-  - pytest=6.1.0=py38_0
   - python=3.8.5=h7579374_1
   - python-levenshtein=0.12.0=py38h1e0a361_1001
   - python_abi=3.8=1_cp38
@@ -85,9 +84,12 @@ dependencies:
   - zlib=1.2.11=h7b6447c_3
   - pip:
     - caldav==0.7.1
+    - coverage==5.3
     - defusedxml==0.6.0
     - lxml==4.5.2
     - passlib==1.7.3
+    - pytest==6.1.1
+    - pytest-cov==2.10.1
     - python-dateutil==2.8.1
     - radicale==3.0.6
     - vobject==0.9.6.1

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -1,0 +1,2 @@
+def test_active():
+    assert 5 == 5

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,2 +1,0 @@
-def test_answer():
-    assert 5 == 5


### PR DESCRIPTION
Running pytest will now automatically generate a coverage report which
will be saves as html and can be viewed in `htmlcov/index.html`