### PR TITLE
Add Reminder automation module

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -4,3 +4,32 @@ class Error(Exception):
 
 class NotImplementedError(Error):
     pass
+
+
+class TimeIsInPastError(Error):
+    """
+    Raised when the time that something is supposed to happen has already
+    passed.
+    """
+
+    def __init__(self, time, message="The specifed time is in the past"):
+        self.time = time
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"{self.message}, time={self.time}"
+
+
+class OSNotSupportedError(Error):
+    """Raised when a feature is not currently supported on the host OS"""
+
+    def __init__(
+        self, os, message="The feature is not supported on the current OS"
+    ):
+        self.os = os
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"{self.message}, os={self.os}"

--- a/lib/automate/__init__.py
+++ b/lib/automate/__init__.py
@@ -11,6 +11,7 @@ class Automate:
         self.modules = [
             import_module("lib.automate.modules.send").Send,
             import_module("lib.automate.modules.schedule").Schedule,
+            import_module("lib.automate.modules.reminder").Reminder,
         ]
         self.verbs = {}
         for module in self.modules:

--- a/lib/automate/modules/reminder.py
+++ b/lib/automate/modules/reminder.py
@@ -1,0 +1,77 @@
+"""
+The reminder automation module
+"""
+from datetime import datetime
+import sys
+from threading import Timer
+from subprocess import run
+
+from lib import OSNotSupportedError, TimeIsInPastError
+from lib.automate.modules import Module
+
+
+class Reminder(Module):
+    """
+    The module of a reminder
+    """
+
+    verbs = ["remind", "reminder", "notify"]
+    supported_os = ["linux"]
+
+    def __init__(self):
+        super(Reminder, self).__init__()
+
+    def notify(self, os, body):
+        """
+        Creates a notification on the users machine. Currently supports Linux
+        (using notify-send).
+
+        :param os: The host machines os
+        :type os: string
+        :param body: The text shown in the notification
+        :type body: string
+        """
+
+        if os == "linux":
+            run(["/usr/bin/notify-send", "Reminder", body])
+        elif os == "win32":
+            # TODO: Add windows call here
+            pass
+
+    def run(self, _to, when, body, _sender):
+        """
+        Schedules a reminder which will show up in the users system at the
+        specified time with the specified information. Raises an error if the
+        host OS is not supported or if the time at which to schedule the
+        reminder is in the past.
+
+        :param _to: Unused
+        :param _sender: Unused
+        :param when: The time to schedule the notification for
+        :type when: datetime.datetime
+        :param body: The text to be shown in the notification
+        :type body: text
+        """
+        when_delta = (
+            when - datetime.now()
+        ).total_seconds()  # convert to difference in seconds
+        if when_delta < 0.0:
+            raise TimeIsInPastError(
+                when.strftime("%Y-%m-%d %H:%M:%S"),
+                "The specified time of the reminder is in the past and can not"
+                + " be scheduled",
+            )
+
+        if sys.platform not in self.supported_os:
+            raise OSNotSupportedError(
+                sys.platform,
+                "Not able to create a reminder in the OS you are using because"
+                + " it is currently not supported by the program",
+            )
+
+        t = Timer(when_delta, lambda: self.notify(sys.platform, body))
+        t.start()
+        return (
+            f"Reminder scheduled for {when.strftime('%Y-%m-%d %H:%M:%S')}",
+            None,
+        )

--- a/lib/cli/commands.py
+++ b/lib/cli/commands.py
@@ -5,6 +5,8 @@ The commands available in the CLI
 import sys
 import os
 
+sys.path.append(".")
+
 from lib.nlp import nlp  # noqa: E402
 
 

--- a/reminder_demo.py
+++ b/reminder_demo.py
@@ -1,0 +1,20 @@
+import sys
+from datetime import datetime, timedelta
+
+from lib import Error
+from lib.automate import Automate
+
+automate = Automate()
+
+"""
+Directly calls the automation module to run a reminder task.
+
+Not using the NLP module since the time is not correctly parsed atm.
+"""
+try:
+    when = datetime.now() + timedelta(seconds=5.0)  # timestamp at: now + 5s
+    body = "This is a test."
+    response = automate.run("remind", None, when, body, None)
+    print(response)
+except Error as err:
+    print(err, file=sys.stdout)

--- a/tests/automate/modules/reminder/conftest.py
+++ b/tests/automate/modules/reminder/conftest.py
@@ -1,0 +1,55 @@
+"""
+Fixtures of the reminder automation module
+"""
+import pytest
+import sys
+
+from lib.automate.modules.reminder import Reminder
+
+
+@pytest.fixture
+def run(monkeypatch):
+    def mock_timer_start(self):
+        pass
+
+    def helper(when, body):
+        reminder = Reminder()
+        # mock the timer used to schedule the reminder
+        monkeypatch.setattr("threading.Timer.start", mock_timer_start)
+        return reminder.run(None, when, body, None)
+
+    yield helper
+
+
+@pytest.fixture
+def notify(monkeypatch):
+    called_with = []
+
+    def mock_subprocess_run(
+        *popenargs,
+        input=None,
+        capture_output=False,
+        timeout=None,
+        check=False,
+        **kwargs
+    ):
+        called_with.append(popenargs)
+
+    def helper(os, body):
+        reminder = Reminder()
+        monkeypatch.setattr(
+            "lib.automate.modules.reminder.run", mock_subprocess_run
+        )
+        return reminder.notify(os, body)
+
+    yield helper, called_with
+
+
+@pytest.fixture
+def mock_os_not_supported(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "MyAwesomeOS")
+
+
+@pytest.fixture
+def mock_os_supported(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")

--- a/tests/automate/modules/reminder/test_notify.py
+++ b/tests/automate/modules/reminder/test_notify.py
@@ -1,0 +1,33 @@
+"""
+Tests regarding the notificitaion of the Reminder automation module
+"""
+
+
+class TestNotifyReminder:
+    """Tests for creating a system notifiction"""
+
+    def test_linux(self, notify):
+        """
+        Tests that a notification is made (by calling notify-send with the
+        correct arguments) when the host OS is linux
+        """
+        # the notify fixture returns two fixture values the first one is the
+        # helper function which can call the notify in Reminder and the second
+        # one is the arguments with which subprocess.run was called with
+        notifyFn = notify[0]
+        notifyFn("linux", "this is a test reminder")
+        called = notify[1]
+        assert called
+
+        # should call the notify-send package with correct arguments
+        args = called[0][0]
+        assert "/usr/bin/notify-send" in args
+        assert "Reminder" in args
+        assert "this is a test reminder" in args
+
+    def test_unknown_os(self, notify):
+        """Tests that nothing is called if the OS is not supported"""
+        notifyFn = notify[0]
+        notifyFn("MyAwesomeOS", "body")
+        called = notify[1]
+        assert not called

--- a/tests/automate/modules/reminder/test_run.py
+++ b/tests/automate/modules/reminder/test_run.py
@@ -1,0 +1,47 @@
+"""
+Tests regarding the running of the Reminder automation module
+"""
+import pytest
+import datetime
+
+from lib import TimeIsInPastError, OSNotSupportedError
+
+
+class TestRunReminder:
+    """Tests for running a reminder automation task"""
+
+    # Note that the arguments run, mock_os_supported are fixtures defined in
+    # the conftest.py file in this directory. This is how you can use fixtures
+    # in your tests if you need to mock something, pytest will automatically
+    # call the tests with the corresponding fixtures.
+    def test_successful(self, run, mock_os_supported):
+        """
+        Tests that a reminder can be scheduled successfully. This does not test
+        that a notification is actually created in the host OS.
+        """
+        valid_time = datetime.datetime.now() + datetime.timedelta(seconds=1.0)
+
+        res, _ = run(valid_time, "body")
+        assert "Reminder scheduled for" in res
+
+    def test_when_in_past(self, run):
+        """
+        Tests that a reminder can not be scheduled for a time which has already
+        passed.
+        """
+        time_in_past = datetime.datetime.min
+
+        with pytest.raises(TimeIsInPastError) as excinfo:
+            run(time_in_past, "body")
+        assert "time of the reminder is in the past" in str(excinfo.value)
+
+    def test_os_not_supported(self, run, mock_os_not_supported):
+        """
+        Tests that trying to create a reminder on a OS which is currently not
+        supported will raise an error indicating this
+        """
+        valid_time = datetime.datetime.now() + datetime.timedelta(seconds=20.0)
+
+        with pytest.raises(OSNotSupportedError) as excinfo:
+            run(valid_time, "body")
+        assert "Not able to create a reminder in the OS" in str(excinfo.value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+
+# This solves an issue with not being able to import modules from the lib/
+# folder in the test files
+sys.path.append(".")
+sys.path.append("..")


### PR DESCRIPTION
Implemented a reminder automation module which given a time and body
will schedule a reminder which will pop-up in the users OS. Currently
only Linux is supported and this will have to be extended to also work
on Windows 10 in the future. This can easily be done by adding code to
`Reminder.notify` which invokes something in the windows system that can
create a notification and adding `win32` to the `supported_os[]`. For Linux
I use the notify-send package which is supposed to be bundled with most
Linux distros.

Reminer.run will raise an error if the time at which the reminder is
supposed to happen has already passed or if the function is called from
a host OS that is not currently supported.

To test this you can run `reminder_demo.py`. The demo is currently not
using the NLP module since I had some problems with how the NLP parsed
time in the text, this will have to be changed in the future.

I also wrote some tests for the reminder module, in these tests I also
mocked some imported library functions so you can check how this can be
done using fixtures if you need to use it in your own tests. The fixtures
can be found in the `conftest.py` file.

Closes #35 