### PR TITLE
Add debug flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The CLI can be started as follows
 
 - `cd` into the project folder
 - Run `python lib/cli/cli.py`
+- You can check available CLI options with `--help`
 
 The CLI should now be running in your terminal. Type `help` for more instructions. Currently the CLI is only capable of sending predefined emails if a word similar to `skicka` is entered by the user. Note that you need to have a [local SMTP debugging server](https://github.com/rpa-tomorrow/substorm-nlp/tree/cli-call-automation#local-smtp-server) running for this to work.
 

--- a/lib/automate/modules/reminder.py
+++ b/lib/automate/modules/reminder.py
@@ -4,12 +4,17 @@ The reminder automation module
 import sys
 import lib.automate.modules.tools.time_convert as tc
 import spacy
+import logging
 
 from datetime import datetime, timedelta
 from threading import Timer
 from subprocess import run
 from lib import OSNotSupportedError, TimeIsInPastError
 from lib.automate.modules import Module
+
+
+# Module logger
+log = logging.getLogger(__name__)
 
 
 class Reminder(Module):
@@ -130,6 +135,7 @@ class Reminder(Module):
                 when.append(token.text)
             elif token.dep_ == "BODY":
                 body.append(token.text)
+            log.debug("%s %s", token.text, token.dep_)
 
         time = datetime.now()
         if len(when) == 0:

--- a/lib/automate/modules/schedule.py
+++ b/lib/automate/modules/schedule.py
@@ -3,12 +3,17 @@ import lib.automate.modules.tools.time_convert as tc
 import pickle
 import os.path
 import spacy
+import logging
 
 from lib.automate.modules import Module, NoSenderError
 from datetime import datetime, timedelta
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+
+
+# Module logger
+log = logging.getLogger(__name__)
 
 # If modifying these scopes, delete the files *.pickle.
 SCOPES = [
@@ -174,6 +179,7 @@ class Schedule(Module):
                 when.append(token.text)
             elif token.dep_ == "BODY":
                 body.append(token.text)
+            log.debug("%s %s", token.text, token.dep_)
 
         time = datetime.now()
         if len(when) == 0:

--- a/lib/automate/modules/send.py
+++ b/lib/automate/modules/send.py
@@ -2,6 +2,7 @@ import smtplib
 import re
 import spacy
 import lib.automate.modules.tools.time_convert as tc
+import logging
 
 from fuzzywuzzy import process as fuzzy
 from email.message import EmailMessage
@@ -9,6 +10,10 @@ from lib.automate.modules import Module, NoSenderError
 from lib import Error
 from lib.settings import SETTINGS
 from datetime import datetime, timedelta
+
+
+# Module logger
+log = logging.getLogger(__name__)
 
 
 class Send(Module):
@@ -165,6 +170,7 @@ class Send(Module):
                 when.append(token.text)
             elif token.dep_ == "BODY":
                 body.append(token.text)
+            log.debug("%s %s", token.text, token.dep_)
 
         time = datetime.now()
         if len(when) == 0:

--- a/lib/cli/cli.py
+++ b/lib/cli/cli.py
@@ -1,13 +1,41 @@
+import plac
 import sys
 import commands
+import logging
 from lib.settings import load_settings
-
 from lib.nlp import nlp  # noqa: E402
 
 MODEL_NAME = "en_rpa_simple"
 
 
-def cli():
+def setup_logger(level):
+    # create logger
+    logger = logging.getLogger()
+    logger.setLevel(level)
+
+    # create console handler and set level to debug
+    ch = logging.StreamHandler()
+    ch.setLevel(level)
+
+    # create formatter
+    formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(name)s: %(message)s')
+
+    # add formatter to ch
+    ch.setFormatter(formatter)
+
+    # add ch to logger
+    logger.addHandler(ch)
+
+
+@plac.annotations(
+    debug=("Enable debug output", "flag", "d"),
+)
+def cli(debug):
+    if debug:
+        setup_logger(logging.DEBUG)
+    else:
+        setup_logger(logging.WARNING)
+
     load_settings()
     print("Loading...")
     n = nlp.NLP(MODEL_NAME)
@@ -24,4 +52,4 @@ def cli():
 
 
 if __name__ == "__main__":
-    cli()
+    plac.call(cli)

--- a/lib/cli/cli.py
+++ b/lib/cli/cli.py
@@ -18,7 +18,7 @@ def setup_logger(level):
     ch.setLevel(level)
 
     # create formatter
-    formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(name)s: %(message)s')
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
 
     # add formatter to ch
     ch.setFormatter(formatter)
@@ -27,9 +27,7 @@ def setup_logger(level):
     logger.addHandler(ch)
 
 
-@plac.annotations(
-    debug=("Enable debug output", "flag", "d"),
-)
+@plac.annotations(debug=("Enable debug output", "flag", "d"))
 def cli(debug):
     if debug:
         setup_logger(logging.DEBUG)


### PR DESCRIPTION
# Proposed changes
This PR adds a debug flag to the CLI. When enabled it will output debug logs to the terminal output.
Usage:
```
python lib/cli/cli.py -d
```
It also adds debug logging in the NLP parts of each module.

# Related issue
Solves (partially) both #85 and #86