### PR TITLE
Fix setup script if conditions and add missing spacy model

### DIFF
--- a/substorm.sh
+++ b/substorm.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-MULTILINE1=$(conda env list \
-	   | grep -F substorm-nlp)
+MULTILINE1=$(conda env list | grep -F substorm-nlp)
 
-if [ MULTILINE1 = ""]; then
+if [ "$MULTILINE1" = "" ]
+then
    echo "no conda env found, creating env..."
    conda env create -f substorm-nlp.yml
 fi
@@ -13,13 +13,12 @@ conda activate substorm-nlp
 
 python -m spacy download en_core_web_sm
 
-MULTILINE2=$(pip list \
-	   | grep -F en-rpa-simple)
+MULTILINE2=$(pip list | grep -F en-rpa-simple)
 
 echo "installed rpa-models..."
 echo "${MULTILINE2}"
 
-if [ MULTILINE2 = "" ]
+if [ "$MULTILINE2" = "" ]
 then
 	echo "missing rpa-models, installing required packages..."
 	pip install -r requirements.txt

--- a/substorm.sh
+++ b/substorm.sh
@@ -12,6 +12,7 @@ source ~/anaconda3/etc/profile.d/conda.sh
 conda activate substorm-nlp
 
 python -m spacy download en_core_web_sm
+python -m spacy download en_core_web_md
 
 MULTILINE2=$(pip list | grep -F en-rpa-simple)
 


### PR DESCRIPTION
Noticed an problem with the if conditions of the setup script which caused the script to not install any models even if no models were installed I also fixed an parse error with the first if statement.

Closes #88

Added missing spacy model `en_core_web_md` to the setup script.

Closes #92 

There is still an issue with this script since as long as at least one model is installed any missing models will not be installed.