### PR TITLE
Disable cache_discovery when building calendar event

### DIFF
--- a/lib/automate/modules/schedule.py
+++ b/lib/automate/modules/schedule.py
@@ -76,7 +76,7 @@ class Schedule(Module):
         creds = self.credentials(username)
 
         # Create Event using Google calendar API
-        service = build("calendar", "v3", credentials=creds)
+        service = build("calendar", "v3", credentials=creds, cache_discovery=False)
         self.service = service
 
         # Check if we are busy


### PR DESCRIPTION
This should fix the warning appearing when a calendar event is created. I don't think cache_discovery is needed for what we are doing.