### PR TITLE
Improve the resolving of email addresses given contact names

### DIFF
--- a/config/contacts.yaml
+++ b/config/contacts.yaml
@@ -13,3 +13,6 @@ John Wilsson:
 John Andersson:
   email:
     address: jAndersson@email.com
+Hugo Wangler:
+  email:
+    address: hugo@email.com

--- a/lib/automate/modules/schedule.py
+++ b/lib/automate/modules/schedule.py
@@ -107,12 +107,7 @@ class Schedule(Module):
             .query(body={"items": [{"id": "primary"}] + to_items, "timeMin": start_time, "timeMax": end_time})
             .execute()
         )
-        to_busy = list(
-            map(
-                lambda x: x[0],
-                filter(lambda x: x[1]["busy"], list(freebusy["calendars"].items())[1:]),
-            )
-        )
+        to_busy = list(map(lambda x: x[0], filter(lambda x: x[1]["busy"], list(freebusy["calendars"].items())[1:]),))
 
         other = f"{', '.join(to_busy[:-1])} and {to_busy[-1]}" if len(to_busy) > 1 else "".join(to_busy)
         if len(freebusy["calendars"]["primary"]["busy"]) and len(to_busy):

--- a/lib/automate/modules/send.py
+++ b/lib/automate/modules/send.py
@@ -1,5 +1,4 @@
 import smtplib
-import re
 import spacy
 import lib.automate.modules.tools.time_convert as tc
 import logging
@@ -10,6 +9,7 @@ from lib.automate.modules import Module, NoSenderError
 from lib import Error
 from lib.settings import SETTINGS
 from datetime import datetime, timedelta
+from lib.utils.email import is_email
 
 
 # Module logger
@@ -55,7 +55,7 @@ class Send(Module):
             self.followup_type = "body"
             return "Found no message body. What message should be sent"
 
-        if not self.is_email(receiver):
+        if not is_email(receiver):
             # filter out the contacts that does not need to be considered
             possible_receivers = fuzzy.extract(receiver, SETTINGS["contacts"].keys())
             possible_receivers = list(filter(lambda x: x[1] > 87, possible_receivers))
@@ -137,11 +137,6 @@ class Send(Module):
             return SETTINGS["contacts"][name]["email"]["address"]
         except KeyError:
             raise NoContactFoundError("No contact with name " + name + " was found")
-
-    def is_email(self, email: str) -> bool:
-        """ Uses regex to check if a incoming string is an email address"""
-        regex = "^([a-z0-9]+[\\._-]?[a-z0-9]+)[@](\\w+[.])+\\w{2,3}$"
-        return re.search(regex, email)
 
     def nlp(self, text):
         """

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -12,9 +12,9 @@ def load_settings():
 
 
 def load_user():
-    """ Load user information from the config file
-        if there are user settings missing then the user
-        is prompted to input these """
+    """Load user information from the config file
+    if there are user settings missing then the user
+    is prompted to input these"""
     old_dir = os.getcwd()
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     with open("../config/user.yaml", "r") as stream:

--- a/lib/utils/contacts.py
+++ b/lib/utils/contacts.py
@@ -12,9 +12,9 @@ def get_emails(names):
     trying to resolve the names with known contacts. If one of the names is a
     valid email it will be added to the resulting email list directly.
 
-    Returns dictrionary with the following key-value pairs:
-        - emails: the emails of the names wich could be found and resolved
-        - uncertain: list of touples containing the name and a list of
+    Returns a dictionary with the following key-value pairs:
+        - emails: the emails of the names which could be found and resolved
+        - uncertain: list of tuples containing the name and a list of
                      the candidates which share the same name. Should be used
                      in a follow-up to resolve the correct contact.
         - unknown: a list of names which could not be resolved from the known

--- a/lib/utils/contacts.py
+++ b/lib/utils/contacts.py
@@ -1,0 +1,56 @@
+from fuzzywuzzy import process as fuzzy
+from lib.settings import SETTINGS, load_local_contacts
+from lib.utils.email import is_email
+
+MIN_SCORE = 75  # the minimum score needed to consider the fuzzy match
+
+
+def get_emails(names):
+    """
+    Returns a dictionary containing three key-value pairs given a string list
+    containing names or emails. The key-value pairs reflects the results of
+    trying to resolve the names with known contacts. If one of the names is a
+    valid email it will be added to the resulting email list directly.
+
+    Returns dictrionary with the following key-value pairs:
+        - emails: the emails of the names wich could be found and resolved
+        - uncertain: list of touples containing the name and a list of
+                     the candidates which share the same name. Should be used
+                     in a follow-up to resolve the correct contact.
+        - unknown: a list of names which could not be resolved from the known
+                   contacts, any invalid emails will also be returned in this
+                   list
+    """
+    load_local_contacts()
+    emails = []
+    uncertain_contacts = []
+    unknown_contacts = []
+
+    for name in names:
+        # Assume valid recipient if input is already an email
+        if is_email(name):
+            emails.append(name)
+            continue
+
+        matches = fuzzy.extract(name, SETTINGS["contacts"].keys())
+        matches = list(filter(lambda x: x[1] > MIN_SCORE, matches))
+        if len(matches) > 1:
+            candidates = []
+            for candidate_name, score in matches:
+                c = (
+                    candidate_name,
+                    SETTINGS["contacts"][candidate_name]["email"]["address"],
+                )
+                candidates.append(c)
+            uncertain_contacts.append((name, candidates))
+        elif len(matches) == 1:
+            name, _ = matches[0]
+            emails.append(SETTINGS["contacts"][name]["email"]["address"])
+        else:
+            unknown_contacts.append(name)
+
+    return {
+        "emails": emails,
+        "uncertain": uncertain_contacts,
+        "unknown": unknown_contacts,
+    }

--- a/lib/utils/email.py
+++ b/lib/utils/email.py
@@ -6,5 +6,5 @@ import re
 
 def is_email(email: str) -> bool:
     """ Uses regex to check if a incoming string is an email address"""
-    regex = "^([a-z0-9]+[\\._-]?[a-z0-9]+)[@](\\w+[.])+\\w{2,3}$"
+    regex = "^([a-zA-Z0-9]+[\\._-]?[a-zA-Z0-9]+)[@](\\w+[.])+\\w{2,3}$"
     return re.search(regex, email)

--- a/lib/utils/email.py
+++ b/lib/utils/email.py
@@ -1,0 +1,10 @@
+"""
+Module with util functions connected to email addresses
+"""
+import re
+
+
+def is_email(email: str) -> bool:
+    """ Uses regex to check if a incoming string is an email address"""
+    regex = "^([a-z0-9]+[\\._-]?[a-z0-9]+)[@](\\w+[.])+\\w{2,3}$"
+    return re.search(regex, email)

--- a/tests/automate/modules/send/test_email.py
+++ b/tests/automate/modules/send/test_email.py
@@ -3,7 +3,7 @@ Tests regarding the handling of email address in the Send automation module
 """
 
 import pytest
-from lib.automate.modules.send import Send, NoContactFoundError
+from lib.automate.modules.send import NoContactFoundError
 
 
 class TestEmailAddress:

--- a/tests/automate/modules/send/test_email.py
+++ b/tests/automate/modules/send/test_email.py
@@ -9,27 +9,6 @@ from lib.automate.modules.send import Send, NoContactFoundError
 class TestEmailAddress:
     """Tests for handling email addresses """
 
-    def test_is_email(self):
-        """
-        Tests that a inputed email address is correctly interpreted as an email address
-        and that a string that is not an email is interpreted as such
-        """
-        send = Send()
-
-        assert send.is_email("first.last@email.com")
-        assert send.is_email("studnt-5@student.ltu.se")
-        assert send.is_email("firlas@student.ltu.se")
-        assert send.is_email("studnt-5@ltu.se")
-        assert send.is_email("10-first@email.com")
-        assert send.is_email("10first@email.co.uk")
-
-        assert not send.is_email("First Last")
-        assert not send.is_email("Last")
-        assert not send.is_email("")
-        assert not send.is_email("First@Last")
-        assert not send.is_email("First@")
-        assert not send.is_email("@Last")
-
     def test_get_email(self, get_test_email):
         """
         Tests that given a name the email address connected can be fetched from

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.fixture
+def four_local_contacts(monkeypatch):
+    four_local_contacts = {
+        "contacts": {
+            "hugo": {"email": {"address": "hugo@email.com"}},
+            "niklas": {"email": {"address": "niklas@email.com"}},
+            "mark": {"email": {"address": "mark@email.com"}},
+            "hugotwo": {"email": {"address": "hugotwo@email.com"}},
+        }
+    }
+    monkeypatch.setattr("lib.utils.contacts.SETTINGS", four_local_contacts)

--- a/tests/utils/contacts/test_get_emails.py
+++ b/tests/utils/contacts/test_get_emails.py
@@ -1,0 +1,66 @@
+"""
+Tests regarding the contacts util functions
+"""
+from lib.utils.contacts import get_emails
+
+
+class TestGetEmails:
+    """Tests for getting the emails from a list of names"""
+
+    def test_unknown(self, four_local_contacts):
+        """
+        Test that an input name that is not in the local contacts will be
+        returned as unknown
+        """
+        names = ["aron"]
+        res = get_emails(names)
+
+        assert res["emails"] == []
+        assert res["uncertain"] == []
+        assert res["unknown"] == ["aron"]
+
+    def test_known(self, four_local_contacts):
+        """
+        Test that names that exist in the contact book will return the email
+        of the contacts
+        """
+        names = ["niklas", "mark"]
+        res = get_emails(names)
+
+        assert res["emails"] == ["niklas@email.com", "mark@email.com"]
+        assert res["uncertain"] == []
+        assert res["unknown"] == []
+
+    def test_uncertain(self, four_local_contacts):
+        """
+        Test that names that can be connected to multiple contacts returns all
+        the candidates as uncertain
+        """
+        names = ["hugo", "mark"]
+        res = get_emails(names)
+
+        assert res["emails"] == ["mark@email.com"]
+        assert res["uncertain"] == [("hugo", [("hugo", "hugo@email.com"), ("hugotwo", "hugotwo@email.com")])]
+        assert res["unknown"] == []
+
+    def test_all(self, four_local_contacts):
+        """
+        Test that it correctly handles multiple names
+        """
+        names = ["hej@gmail.com", "hugo", "aron", "mark", "gustav", "niklas"]
+        res = get_emails(names)
+
+        assert res["emails"] == ["hej@gmail.com", "mark@email.com", "niklas@email.com"]
+        assert res["uncertain"] == [("hugo", [("hugo", "hugo@email.com"), ("hugotwo", "hugotwo@email.com")])]
+        assert res["unknown"] == ["aron", "gustav"]
+
+    def test_name_is_email(self, four_local_contacts):
+        """
+        Test that an email will be added to the known emails
+        """
+        names = ["hej@email.com", "test@noemail"]
+        res = get_emails(names)
+
+        assert res["emails"] == ["hej@email.com"]
+        assert res["uncertain"] == []
+        assert res["unknown"] == ["test@noemail"]

--- a/tests/utils/email/test_is_email.py
+++ b/tests/utils/email/test_is_email.py
@@ -1,0 +1,23 @@
+from lib.utils.email import is_email
+
+
+class TestIsEmail:
+    def test_is_email(self):
+        """
+        Tests that a inputed email address is correctly interpreted as an email address
+        and that a string that is not an email is interpreted as such
+        """
+
+        assert is_email("first.last@email.com")
+        assert is_email("studnt-5@student.ltu.se")
+        assert is_email("firlas@student.ltu.se")
+        assert is_email("studnt-5@ltu.se")
+        assert is_email("10-first@email.com")
+        assert is_email("10first@email.co.uk")
+
+        assert not is_email("First Last")
+        assert not is_email("Last")
+        assert not is_email("")
+        assert not is_email("First@Last")
+        assert not is_email("First@")
+        assert not is_email("@Last")

--- a/tests/utils/email/test_is_email.py
+++ b/tests/utils/email/test_is_email.py
@@ -14,6 +14,7 @@ class TestIsEmail:
         assert is_email("studnt-5@ltu.se")
         assert is_email("10-first@email.com")
         assert is_email("10first@email.co.uk")
+        assert is_email("jAndersson@email.com")
 
         assert not is_email("First Last")
         assert not is_email("Last")


### PR DESCRIPTION
# Proposed changes
### Misc
* Created a `utils/` directory and moved existing `is_email()` from Schedule module to this folder to allow for reusability
* Updated the email Regex to also consider emails written in uppercase to be valid (had an issue with this and thought my code was incorrect for a while :P)

### Resolving emails
- Created a new util function which is able to resolve the email addresses of local contacts given their names (or valid emails directly). This is done by returning a dictionary containing:
    - emails: the known emails resolved (if input is a valid email they will automatically be added to emails)
   - uncertain: the name and potential candidates and their emails, will contain any contacts which could not be resolved i.e. multiple with same name
    - unknown: the input names which could not be resolved to any local
contacts

This function is now used when trying to resolve the emails of meeting attendees. Necessary follow-ups has also been added such as which contanct to pick (if uncertain is not empty) and if the meeting should still be scheduled without the unknown contact.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- [x] "schedule a meeting with hello@email.com at 15:00" should create the meeting with the specified email without any follow-ups.
- [x] "schedule a meeting with Hugo at 15:00" should create the meeting and Hugo should be resolved to hugo@email.com so the guest in the calendar should be hugo@email.com
- [x] "schedule a meeting with John at 15:00" should prompt the user to pick which John to invite to the meeting. If the user responds with an invalid input (out of range or NaN) they should be prompted again until valid. On valid input the correct John should be listed as a guest in the calendar.
- [x] "schedule a meeting with Mark at 15:00" should prompt the user if the meeting should be scheduled without the unknown contact Mark.
- [x] `pytest` will run the tests I added for the utility function itself `get_emails()`

I have not been able to test the Schedule module with multiple attendees since the model is not able to correctly parse multiple attendees. But it should still work in the future if we support it since I remove/update the resolved entries in `to` and recursively call the `parse_processed` function to continue resolving any attendees.

# Related issue
Closes #74 and Closes #73 
If you can think of any more existing functionality that should be moved to the utils folder pls move them 
