### PR TITLE
Add variable debug option to CLI

### DIFF
--- a/lib/cli/cli.py
+++ b/lib/cli/cli.py
@@ -27,12 +27,24 @@ def setup_logger(level):
     logger.addHandler(ch)
 
 
-@plac.annotations(debug=("Enable debug output", "flag", "d"))
-def cli(debug):
-    if debug:
-        setup_logger(logging.DEBUG)
-    else:
+@plac.annotations(
+    debug=("Set the debug logging level which will be output", "option", "d", str),
+    verbose=("Enable verbose output", "flag", "v"),
+)
+def cli(debug, verbose):
+    try:
+        if debug is not None:
+            setup_logger(debug)
+
+        if debug is not None and verbose:
+            logging.warning("Verbose and debug output are both enabled. Ignoring verbose flag!")
+        elif verbose:
+            setup_logger(logging.INFO)
+        else:
+            setup_logger(logging.WARNING)
+    except ValueError:
         setup_logger(logging.WARNING)
+        logging.warning("Could not parse debug flag. Using default log settings.")
 
     load_settings()
     print("Loading...")

--- a/lib/cli/cli.py
+++ b/lib/cli/cli.py
@@ -33,18 +33,18 @@ def setup_logger(level):
 )
 def cli(debug, verbose):
     try:
+        if debug is not None and verbose:
+            print("WARNING: Verbose and debug output are both enabled. Ignoring verbose flag!")
+
         if debug is not None:
             setup_logger(debug)
-
-        if debug is not None and verbose:
-            logging.warning("Verbose and debug output are both enabled. Ignoring verbose flag!")
         elif verbose:
             setup_logger(logging.INFO)
         else:
             setup_logger(logging.WARNING)
     except ValueError:
         setup_logger(logging.WARNING)
-        logging.warning("Could not parse debug flag. Using default log settings.")
+        print("WARNING: Could not parse debug flag. Using default log settings.")
 
     load_settings()
     print("Loading...")


### PR DESCRIPTION
# Proposed changes
* Adds a `--verbose` flag for INFO logging output
* Changes the `--debug` flag to an option instead which requires the debug level output. E.g. `--debug DEBUG`

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- [ ] `python lib/cli/cli.py -d DEBUG` check that you get DEBUG output when trying to run any module
- [ ] `python lib/cli/cli.py -d DEBUG -v` should ignore the verbose flag as debug has priority

# Related issue
Fixes #85 
