### PR TITLE
Decouple cli from settings

### DIFF
--- a/lib/cli/cli.py
+++ b/lib/cli/cli.py
@@ -2,7 +2,8 @@ import plac
 import sys
 import commands
 import logging
-from lib.settings import load_settings, SETTINGS
+from config import load_settings_from_cli
+from lib.settings import SETTINGS
 from lib.nlp import nlp  # noqa: E402
 
 
@@ -32,7 +33,7 @@ def cli(debug):
     else:
         setup_logger(logging.WARNING)
 
-    load_settings()
+    load_settings_from_cli()
     print("Loading...")
     n = nlp.NLP(SETTINGS["nlp_models"]["basic"], SETTINGS["nlp_models"]["spacy"])
     print("Ready!")

--- a/lib/cli/commands.py
+++ b/lib/cli/commands.py
@@ -4,10 +4,7 @@ The commands available in the CLI
 
 import sys
 import os
-
-sys.path.append(".")
-
-from lib.settings import set_language  # noqa: E402
+from config import config_model_language
 
 
 def commands(arr, nlp):
@@ -19,7 +16,7 @@ def commands(arr, nlp):
     elif arr[0] == "help" or arr[0] == "h":
         prompt()
     elif arr[0] == "language" or arr[0] == "lang":
-        set_language()
+        config_model_language()
     else:
         listToStr = " ".join(map(str, arr))
         try:

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -1,54 +1,16 @@
 import os
 import yaml
-from lib.cli.config import config_user_name, config_email_address, config_email_host, config_model_language
 
 SETTINGS = {}
 
 
-def load_settings():
-    """ Load settings from the config files located in /config"""
-    load_user()
-    load_local_contacts()
-
-
 def load_user():
-    """Load user information from the config file
-    if there are user settings missing then the user
-    is prompted to input these"""
+    """Load user information from the config file"""
     old_dir = os.getcwd()
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     with open("../config/user.yaml", "r") as stream:
         SETTINGS["user"] = yaml.safe_load(stream)
-
-    # Flag for checking if there is a need to update the config by writing to a file
-    update = False
-
-    if SETTINGS["user"]["name"] == "":
-        SETTINGS["user"]["name"] = config_user_name()
-        update = True
-
-    email_config = SETTINGS["user"]["email"]
-    if email_config["address"] == "":
-        email_config["address"] = config_email_address()
-        update = True
-
-    if email_config["host"] == "":
-        email_config = config_email_host(email_config)
-        update = True
-
-    if SETTINGS["user"]["model_language"] is None:
-        languages = []
-        with open("../config/nlp_models.yaml", "r") as stream:
-            languages = list(yaml.safe_load(stream).keys())
-        SETTINGS["user"]["model_language"] = config_model_language(languages)
-        update = True
-
-    if update:
-        update_settings("../config/user", SETTINGS["user"])
-        print("User config updated")
     os.chdir(old_dir)
-
-    load_nlp_models_config(SETTINGS["user"]["model_language"])
 
 
 def load_local_contacts():
@@ -62,30 +24,30 @@ def load_local_contacts():
 
 def update_settings(file_path: str, data: dict):
     """Writes to a yaml config file"""
+    old_dir = os.getcwd()
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
     with open(file_path + ".yaml", "w", encoding="utf8") as outfile:
         yaml.dump(data, outfile)
+    os.chdir(old_dir)
+
+
+def get_model_languages():
+    """Reads a list of languages from the nlp_model config file"""
+    languages = []
+
+    old_dir = os.getcwd()
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    with open("../config/nlp_models.yaml", "r") as stream:
+        languages = list(yaml.safe_load(stream).keys())
+    os.chdir(old_dir)
+
+    return languages
 
 
 def load_nlp_models_config(language):
-    """ Loads the language specific nlp model names from the config file """
+    """Loads the language specific nlp model names from the config file"""
     old_dir = os.getcwd()
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     with open("../config/nlp_models.yaml", "r") as stream:
         SETTINGS["nlp_models"] = yaml.safe_load(stream)[language]
     os.chdir(old_dir)
-
-
-def set_language():
-    old_dir = os.getcwd()
-    os.chdir(os.path.dirname(os.path.abspath(__file__)))
-
-    languages = []
-    with open("../config/nlp_models.yaml", "r") as stream:
-        languages = list(yaml.safe_load(stream).keys())
-    SETTINGS["user"]["model_language"] = config_model_language(languages)
-
-    update_settings("../config/user", SETTINGS["user"])
-    print("User config updated")
-    os.chdir(old_dir)
-
-    load_nlp_models_config(SETTINGS["user"]["model_language"])

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -4,6 +4,13 @@ import yaml
 SETTINGS = {}
 
 
+def load_settings():
+    """ Load settings from the config files located in /config"""
+    load_user()
+    load_nlp_models_config(SETTINGS["user"]["model_language"])
+    load_local_contacts()
+
+
 def load_user():
     """Load user information from the config file"""
     old_dir = os.getcwd()


### PR DESCRIPTION
# Proposed changes
* Decouple cli from settings, to make it possible for the GUI to reuse the settings code.


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- [x] Ran the reminder demo, expect the normal results.
- [x] Ran the email_demo demo, expect the normal results.
- [x] Ran reminder through cli, expect the normal results.
- [x] Remove all user settings, then run the cli. Expect to be prompted to insert all the user settings.

# Related issue
closes #111 
