### PR TITLE
Convert time to UTC when scheduling event

### DIFF
--- a/lib/automate/google.py
+++ b/lib/automate/google.py
@@ -6,9 +6,10 @@ from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the files *.pickle.
 from lib import Error
+from lib.utils.tools import time_convert as tc
 
+# If modifying these scopes, delete the files *.pickle.
 SCOPES = [
     "https://www.googleapis.com/auth/calendar.events.owned",
     "https://www.googleapis.com/auth/calendar.readonly",
@@ -64,8 +65,8 @@ class Event:
 
     def to_dict(self):
         # Parse Time
-        start_time = self.start.isoformat() + "Z"  # 'Z' indicates UTC time
-        end_time = self.end.isoformat() + "Z"  # 'Z' indicates UTC time
+        start_time = tc.local_to_utc_time(self.start).isoformat()
+        end_time = tc.local_to_utc_time(self.end).isoformat()
 
         return {
             "summary": self.summary,


### PR DESCRIPTION
# Proposed changes
* Use the utc converter created by @Blinningjr for the start and end time of a meeting 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- [ x] Schedule a meeting at a specific time and the time in the google calendar should be the same as specified (not -1 hr)

# Related issue
This was fixed by @Blinningjr in PR #103 but when we moved the event to `google.py` the usage of the new function was not included. This just reverts that change.
