### PR TITLE
Remove Calendar Events

### DIFF
--- a/config/contacts.yaml
+++ b/config/contacts.yaml
@@ -3,7 +3,7 @@ Aron Widforss:
     address: aron@antarkt.is
 John Doe:
   email:
-    address: johndoe@email.com
+    address: john@email.com
 Niklas:
   email:
     address: niklas@email.com

--- a/examples/remove_schedule_demo.py
+++ b/examples/remove_schedule_demo.py
@@ -1,5 +1,8 @@
 import sys
 
+sys.path.append(".")
+sys.path.append("..")
+
 from lib import Error
 from lib.automate import Automate
 from lib.nlp import nlp
@@ -8,18 +11,14 @@ from lib.settings import load_settings
 
 load_settings()
 automate = Automate()
-n = nlp.NLP("en_rpa_simple")
+n = nlp.NLP("en_rpa_simple", "en_core_web_md")
 
 # Enable the CalDav server before running the following
 try:
-    text = "set meeting with Niklas at 20:00"
-    # Have to use automation module directly because the NLP model does not
-    # support Schedule yet
-    # response = n.run(text)
     when = datetime.now() + timedelta(hours=5.0)  # timestamp at: now + 5 hrs
-    # when = datetime.fromisoformat("2020-11-02T15:40:00")
-    response = automate.run("unschedule", ["rpa@substorm.com"], None, None)
-
+    text = "unschedule meeting with john"
+    print("input:", text)
+    response = n.run(text)
     print(response)
 except Error as err:
     print(err, file=sys.stdout)

--- a/examples/remove_schedule_demo.py
+++ b/examples/remove_schedule_demo.py
@@ -3,11 +3,11 @@ import sys
 sys.path.append(".")
 sys.path.append("..")
 
-from lib import Error
-from lib.automate import Automate
-from lib.nlp import nlp
-from datetime import datetime, timedelta
-from lib.settings import load_settings
+from lib import Error  # noqa: E402
+from lib.automate import Automate  # noqa: E402
+from lib.nlp import nlp  # noqa: E402
+from datetime import datetime, timedelta  # noqa: E402
+from lib.settings import load_settings  # noqa: E402
 
 load_settings()
 automate = Automate()

--- a/examples/schedule_demo.py
+++ b/examples/schedule_demo.py
@@ -12,7 +12,7 @@ n = nlp.NLP("en_rpa_simple", "en_core_web_md")
 
 # Enable the CalDav server before running the following
 try:
-    text = "schedule meeting with test@example.com at 20:00"
+    text = "schedule meeting with john@email.com at 20:00"
     response = n.run(text)
 
     print(response)

--- a/lib/automate/__init__.py
+++ b/lib/automate/__init__.py
@@ -11,6 +11,7 @@ class Automate:
         self.modules = [
             import_module("lib.automate.modules.send").Send,
             import_module("lib.automate.modules.schedule").Schedule,
+            import_module("lib.automate.modules.remove_schedule").RemoveSchedule,
             import_module("lib.automate.modules.reminder").Reminder,
         ]
         self.verbs = {}

--- a/lib/automate/google.py
+++ b/lib/automate/google.py
@@ -104,6 +104,17 @@ class Calendar:
         freebusy = map(lambda x: x[0], filter(lambda x: x[1]["busy"], freebusy["calendars"].items()))
         return list(freebusy)
 
+    def get_events(self):
+        """ 
+        Returns a list of events from the primary calendar
+        Does not return past events that has already ended 
+        """
+        now = dt.now()
+        return self.service.events().list(calendarId="primary", timeMin=(now.isoformat() + "Z")).execute()["items"]
+
+    def delete_event(self, eventId: str):
+        self.service.events().delete(calendarId="primary", eventId=eventId).execute()
+
 
 class People:
     def __init__(self, google: Google, username):

--- a/lib/automate/google.py
+++ b/lib/automate/google.py
@@ -105,9 +105,9 @@ class Calendar:
         return list(freebusy)
 
     def get_events(self):
-        """ 
+        """
         Returns a list of events from the primary calendar
-        Does not return past events that has already ended 
+        Does not return past events that has already ended
         """
         now = dt.now()
         return self.service.events().list(calendarId="primary", timeMin=(now.isoformat() + "Z")).execute()["items"]

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -66,9 +66,13 @@ class RemoveSchedule(Module):
 
     def followup(self, answer):
         """ """
+        print(answer)
         if self.followup_type == "self_busy":
-            self.service.events().delete(calendarId="primary", eventId=self.event["id"]).execute()
-            return f"'{self.event['summary']}' was removed from your calendar", None
+            if answer.lower() in ["y", "yes"]:
+                self.service.events().delete(calendarId="primary", eventId=self.event["id"]).execute()
+                return f"'{self.event['summary']}' was removed from your calendar", None
+            else:
+                return "Event not removed", None
         else:
             raise NotImplementedError("")
 

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -1,0 +1,128 @@
+from __future__ import print_function
+from lib.automate.modules import Module, NoSenderError
+from datetime import datetime, timedelta
+from lib import Error
+from fuzzywuzzy import process as fuzzy
+import pickle
+import os.path
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+
+# If modifying these scopes, delete the files *.pickle.
+SCOPES = [
+    "https://www.googleapis.com/auth/calendar.events.owned",
+    "https://www.googleapis.com/auth/calendar.readonly",
+]
+
+
+class RemoveSchedule(Module):
+    verbs = ["unschedule", "remove"]
+
+    def __init__(self):
+        super(RemoveSchedule, self).__init__()
+
+    def run(self, to, when, body, sender):
+        self.to = to
+        self.when = when
+        self.body = body
+        self.sender = sender
+        self.followup_type = None
+        self.event = None
+
+        if not isinstance(when, datetime):
+            self.followup_type = "when"
+            return (
+                None,
+                "Could not parse date to schedule to.\nPlease enter date in YYYYMMDD HH:MM format",
+            )
+
+        # Parse Time
+        duration = 20  # TODO: Parse from input
+        start_time = self.when.isoformat() + "Z"  # 'Z' indicates UTC time
+        end_time = (self.when + timedelta(minutes=duration)).isoformat() + "Z"  # 'Z' indicates UTC time
+
+        # Get or create user credentials
+        settings = sender["email"]
+        username = settings.get("username")
+        creds = self.credentials(username)
+
+        service = build("calendar", "v3", credentials=creds)
+        self.service = service
+
+        if body:
+            self.get_event_by_summary(body)
+        elif start_time:
+            self.get_event_by_timestamp(start_time, end_time)
+
+        print(self.event)
+
+        start_time = self.event["start"]["dateTime"]
+        self.followup_type = "self_busy"
+        return (
+            None,
+            f"You have the event '{self.event['summary']}' scheduled at {start_time}. Do you want to remove it? [Y/n]",
+        )
+
+    def followup(self, answer):
+        """ """
+        if self.followup_type == "self_busy":
+            self.service.events().delete(calendarId="primary", eventId=self.event["id"]).execute()
+            return f"'{self.event['summary']}' was removed from your calendar", None
+        else:
+            raise NotImplementedError("")
+
+    def credentials(self, username):
+        """
+        The file token.pickle stores the user's access and refresh tokens, and is
+        created automatically when the authorization flow completes for the first
+        time.
+        """
+        creds = None
+        pickle_filename = f"{username}_token.pickle"
+
+        if os.path.exists(pickle_filename):
+            with open(pickle_filename, "rb") as token:
+                creds = pickle.load(token)
+        # If there are no (valid) credentials available, let the user log in.
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file("client_secret.json", SCOPES)
+                creds = flow.run_local_server(port=0)
+            # Save the credentials for the next run
+            with open(pickle_filename, "wb") as token:
+                pickle.dump(creds, token)
+
+        return creds
+
+    def get_event_by_timestamp(self, start_time, end_time):
+        # Check if we are busy
+        freebusy = (
+            self.service.freebusy()
+            .query(body={"items": [{"id": "primary"}], "timeMin": start_time, "timeMax": end_time})
+            .execute()
+        )
+
+        if len(freebusy["calendars"]["primary"]["busy"]):
+            self.followup_type = "self_busy"
+            start_time = freebusy["calendars"]["primary"]["busy"][0]["start"]
+            end_time = freebusy["calendars"]["primary"]["busy"][0]["end"]
+
+            self.event = (
+                self.service.events()
+                .list(calendarId="primary", timeMin=start_time, timeMax=end_time)
+                .execute()["items"][0]
+            )
+        else:
+            raise NoEventFoundError("Could not find anything scheduled at the given time")
+
+    def get_event_by_summary(self, summary):
+        events = self.service.events().list(calendarId="primary").execute()["items"]
+
+        self.event = fuzzy.extractOne(summary, events)[0]
+
+
+class NoEventFoundError(Error):
+    pass

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -1,6 +1,4 @@
 from __future__ import print_function
-import pickle
-import os.path
 import logging
 import spacy
 
@@ -11,11 +9,7 @@ from lib.automate.modules import Module
 import lib.utils.tools.time_convert as tc
 from datetime import datetime, timedelta
 from fuzzywuzzy import process as fuzzy
-from lib.utils.contacts import get_emails, prompt_contact_choice, followup_contact_choice
-
-from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
+from lib.utils.contacts import prompt_contact_choice, followup_contact_choice
 
 log = logging.getLogger(__name__)
 
@@ -45,6 +39,7 @@ class RemoveSchedule(Module):
         calendar = google.calendar(settings)
         self.calendar = calendar
 
+        self.events = []
         self.event = None
 
         return self.prepare_processed(to, when, body, sender)

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -51,10 +51,12 @@ class RemoveSchedule(Module):
 
         if self.event:
             start_time = self.event["start"]["dateTime"]
+            start_time = datetime.fromisoformat(start_time)
+            formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
             self.followup_type = "self_busy"
             return (
                 None,
-                f"You have the event '{self.event['summary']}' scheduled at {start_time}. Do you want to remove it? [Y/n]",
+                f"You have the event '{self.event['summary']}' scheduled at {formated_time}. Do you want to remove it? [Y/n]",
             )
         else:
             return

--- a/remove_schedule_demo.py
+++ b/remove_schedule_demo.py
@@ -16,8 +16,8 @@ try:
     # Have to use automation module directly because the NLP model does not
     # support Schedule yet
     # response = n.run(text)
-    when = datetime.utcnow() + timedelta(hours=5.0)  # timestamp at: now + 5 hrs
-    response = automate.run("unschedule", ["rpa@substorm.com"], when, "Schedule demo")
+    when = datetime.fromisoformat("2020-11-02T15:40:00")
+    response = automate.run("unschedule", ["rpa@substorm.com"], when, "shedule demo")
 
     print(response)
 except Error as err:

--- a/remove_schedule_demo.py
+++ b/remove_schedule_demo.py
@@ -16,8 +16,9 @@ try:
     # Have to use automation module directly because the NLP model does not
     # support Schedule yet
     # response = n.run(text)
-    when = datetime.fromisoformat("2020-11-02T15:40:00")
-    response = automate.run("unschedule", ["rpa@substorm.com"], when, "shedule demo")
+    when = datetime.now() + timedelta(hours=5.0)  # timestamp at: now + 5 hrs
+    # when = datetime.fromisoformat("2020-11-02T15:40:00")
+    response = automate.run("unschedule", ["rpa@substorm.com"], when, None)
 
     print(response)
 except Error as err:

--- a/remove_schedule_demo.py
+++ b/remove_schedule_demo.py
@@ -18,7 +18,7 @@ try:
     # response = n.run(text)
     when = datetime.now() + timedelta(hours=5.0)  # timestamp at: now + 5 hrs
     # when = datetime.fromisoformat("2020-11-02T15:40:00")
-    response = automate.run("unschedule", ["rpa@substorm.com"], when, None)
+    response = automate.run("unschedule", ["rpa@substorm.com"], None, None)
 
     print(response)
 except Error as err:

--- a/remove_schedule_demo.py
+++ b/remove_schedule_demo.py
@@ -1,0 +1,24 @@
+import sys
+
+from lib import Error
+from lib.automate import Automate
+from lib.nlp import nlp
+from datetime import datetime, timedelta
+from lib.settings import load_settings
+
+load_settings()
+automate = Automate()
+n = nlp.NLP("en_rpa_simple")
+
+# Enable the CalDav server before running the following
+try:
+    text = "set meeting with Niklas at 20:00"
+    # Have to use automation module directly because the NLP model does not
+    # support Schedule yet
+    # response = n.run(text)
+    when = datetime.utcnow() + timedelta(hours=5.0)  # timestamp at: now + 5 hrs
+    response = automate.run("unschedule", ["rpa@substorm.com"], when, "Schedule demo")
+
+    print(response)
+except Error as err:
+    print(err, file=sys.stdout)


### PR DESCRIPTION
# Proposed changes
* Add a automation module for removing calendar event
    * Remove events based on timestamp, participants or event name
* This module is using the Schedule meeting NLP Model, 
    * this one does not seem to parse the body though and needs to be looked over
## How Has This Been Tested?

- [X] Using the CLI, create an event at time 20:00. Then enter "remove meeting at 20:00". The user should be prompted to remove the event from the calendar 
- [X] Using the CLI, create an event with a participant "John", then enter "remove meeting with John", The user should be prompted to remove the event from the calendar
- [X] Using the CLI, create two events at the same time, ex: 20:00. then enter "remove the meeting at 20:00", The user should be able to choose which one to remove.
# Related issue
Closes #69 
