### PR TITLE
Add full name parsing utilities and improve module/model initialization

### DIFF
--- a/config/nlp_models.yaml
+++ b/config/nlp_models.yaml
@@ -5,3 +5,4 @@ english:
     reminder: en_rpa_simple_reminder
     schedule: en_rpa_simple_calendar
     spacy: en_core_web_md
+    ner: xx_ent_wiki_sm

--- a/lib/automate/__init__.py
+++ b/lib/automate/__init__.py
@@ -19,7 +19,7 @@ class Automate:
         self.loaded_modules = []
         self.modules = []
         self.verbs = []
-        # Shared models added here
+        # Should be added dynamically from the settings
         self.pool = ModelPool(["xx_ent_wiki_sm"])
 
         for module in self._modules:

--- a/lib/automate/__init__.py
+++ b/lib/automate/__init__.py
@@ -19,8 +19,7 @@ class Automate:
         self.loaded_modules = []
         self.modules = []
         self.verbs = []
-        # Should be added dynamically from the settings
-        self.pool = ModelPool(["xx_ent_wiki_sm"])
+        self.pool = ModelPool([SETTINGS["nlp_models"]["ner"]])
 
         for module in self._modules:
             self.verbs.extend(module.verbs)

--- a/lib/automate/__init__.py
+++ b/lib/automate/__init__.py
@@ -3,29 +3,56 @@ from importlib import import_module
 
 from lib import Error
 from lib.settings import SETTINGS
+from lib.automate.pool import ModelPool
 
 
 class Automate:
     def __init__(self):
         """ Register new modules here """
-        self.modules = [
+        self._modules = [
             import_module("lib.automate.modules.send").Send,
             import_module("lib.automate.modules.schedule").Schedule,
             import_module("lib.automate.modules.remove_schedule").RemoveSchedule,
             import_module("lib.automate.modules.reminder").Reminder,
         ]
         self.response_callback = None
-        self.verbs = {}
-        for module in self.modules:
-            for verb in module.verbs:
-                self.verbs[verb] = module
+        self.loaded_modules = []
+        self.modules = []
+        self.verbs = []
+        # Shared models added here
+        self.pool = ModelPool(["xx_ent_wiki_sm"])
+
+        for module in self._modules:
+            self.verbs.extend(module.verbs)
+            self.modules.append((module.verbs, module))
+
+    def _load_module(self, module_name):
+        fuzzy_match, score = fuzzy.extractOne(module_name, self.get_verbs())
+
+        if score > 30:
+            # Checks if module is loaded and if so returns it
+            for verbs, module in self.loaded_modules:
+                if fuzzy_match in verbs:
+                    return module
+
+            # If module not yet loaded, init it and mark it as loaded
+            for verbs, module in self.modules:
+                if fuzzy_match in verbs:
+                    loaded = module(self.pool)
+                    self.loaded_modules.append((verbs, loaded))
+                    return loaded
+
+            raise AutomationNotFoundError("Automation module not found")
+
+        else:
+            raise AutomationNotFoundError("Automation module not found")
 
     def get_verbs(self):
         """
         :return: A list of keywords for the registered automation modules.
         :rtype: list[string]
         """
-        return list(self.verbs.keys())
+        return self.verbs
 
     def get_senders(self):
         """
@@ -53,14 +80,7 @@ class Automate:
             else:
                 return instance
 
-        if module_name in self.verbs:
-            instance = self.verbs[module_name]()
-        else:
-            fuzzy_match, score = fuzzy.extractOne(module_name, self.get_verbs())
-            if score > 30:
-                instance = self.verbs[fuzzy_match]()
-            else:
-                raise AutomationNotFoundError("Automation module not found")
+        instance = self._load_module(module_name)
 
         followup = instance.prepare(SETTINGS["nlp_models"], text, sender)
         if self.response_callback:

--- a/lib/automate/modules/__init__.py
+++ b/lib/automate/modules/__init__.py
@@ -1,11 +1,17 @@
+import logging
+
 from lib import Error
+
+# Module logger
+log = logging.getLogger(__name__)
 
 
 class Module:
     verbs = []
+    model_pool = None
 
-    def __init__(self):
-        pass
+    def __init__(self, model_pool):
+        self.model_pool = model_pool
 
     def prepare(self, nlp_model_names, text, sender):
         raise NotImplementedError("Method not implemented")

--- a/lib/automate/modules/reminder.py
+++ b/lib/automate/modules/reminder.py
@@ -25,8 +25,8 @@ class Reminder(Module):
     verbs = ["remind", "reminder", "notify"]
     supported_os = ["linux"]
 
-    def __init__(self):
-        super(Reminder, self).__init__()
+    def __init__(self, model_pool):
+        super(Reminder, self).__init__(model_pool)
         self.nlp_model = None
 
     def notify(self, os, body):

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -25,8 +25,8 @@ SCOPES = [
 class RemoveSchedule(Module):
     verbs = ["unschedule", "remove"]
 
-    def __init__(self):
-        super(RemoveSchedule, self).__init__()
+    def __init__(self, model_pool):
+        super(RemoveSchedule, self).__init__(model_pool)
         self.nlp_model = None
 
     def prepare(self, nlp_model_names, text, sender):

--- a/lib/automate/modules/schedule.py
+++ b/lib/automate/modules/schedule.py
@@ -17,8 +17,8 @@ log = logging.getLogger(__name__)
 class Schedule(Module):
     verbs = ["book", "schedule", "meeting"]
 
-    def __init__(self):
-        super(Schedule, self).__init__()
+    def __init__(self, model_pool):
+        super(Schedule, self).__init__(model_pool)
         self.nlp_model = None
 
     def prepare(self, nlp_model_names, text, sender):

--- a/lib/automate/modules/send.py
+++ b/lib/automate/modules/send.py
@@ -164,7 +164,7 @@ class Send(Module):
 
         _body = " ".join(body)
 
-        self.model_pool.release_model("xx_ent_wiki_sm")
+        self.model_pool.release_model(ner_model)
         return (to, time, _body)
 
 

--- a/lib/automate/modules/send.py
+++ b/lib/automate/modules/send.py
@@ -134,14 +134,11 @@ class Send(Module):
         Lets the reminder model work on the given text.
         """
         doc = self.nlp_model(text)
+        ner_model = asyncio.run(self.model_pool.acquire_model("xx_ent_wiki_sm"))
+
         to = []
         when = []
         body = []
-
-        # Create event loop here. Unless we decide to use async/await in the whole program
-        # you have to do this the ugly way
-        ner_model = asyncio.run(self.model_pool.acquire_model("xx_ent_wiki_sm"))
-
         persons = ner.get_persons(ner_model, text)
 
         for token in doc:

--- a/lib/automate/pool.py
+++ b/lib/automate/pool.py
@@ -51,14 +51,14 @@ class ModelPool:
 
         raise NoModelFoundError("No model by the name %s found", model_name)
 
-    def release_model(self, model_name):
+    def release_model(self, model):
         """
         Relases the lock for a model such that others can use it.
         :param model_name: The name of the spacy model to release.
         :type model_name: string
         """
-        for name, _, lock in self.pool:
-            if name == model_name:
+        for name, shared_model, lock in self.pool:
+            if model == shared_model:
                 lock.release()
                 log.debug("Released lock for model %s", name)
 

--- a/lib/automate/pool.py
+++ b/lib/automate/pool.py
@@ -1,0 +1,67 @@
+import spacy
+import asyncio
+import logging
+
+from lib import Error
+
+# Module logger
+log = logging.getLogger(__name__)
+
+
+class ModelPool:
+    """
+    ModelPool contains a pool of spacy models to be shared between
+    different automation modules. When a model is acquired a lock will
+    be put on it such that no other modules can use it. When a lock is released
+    the model can be used by the next module that is requesting it.
+
+    Uses non-thread-safe locks!
+    """
+    # Stored as (name, model, lock)
+    pool = []
+
+    def __init__(self, model_names):
+        """
+        From the given model names, loads the models into memory, in the shared
+        model pool.
+        :param shared_models: Names of the spacy models to be shared.
+        :type list[string]
+        """
+        for name in model_names:
+            model = spacy.load(name)
+            lock = asyncio.Lock()
+            self.pool.append((name, model, lock))
+        log.debug("Initialized shared models in pool")
+
+    async def acquire_model(self, model_name):
+        """
+        Acquires a spacy model in the model pool. If the model is already in
+        use, it will wait until the model is released, lock it and then return
+        the model. If the model is not found, an exception will be raised.
+        :param model_name: The name of the spacy model to acquire.
+        :type model_name: string
+        :return: The spacy model
+        """
+        for name, model, lock in self.pool:
+            if name == model_name:
+                log.debug("Waiting to acquire lock for model %s", name)
+                await lock.acquire()
+                log.debug("Acquired lock for model %s", name)
+                return model
+
+        raise NoModelFoundError("No model by the name %s found", model_name)
+
+    def release_model(self, model_name):
+        """
+        Relases the lock for a model such that others can use it.
+        :param model_name: The name of the spacy model to release.
+        :type model_name: string
+        """
+        for name, _, lock in self.pool:
+            if name == model_name:
+                lock.release()
+                log.debug("Released lock for model %s", name)
+
+
+class NoModelFoundError(Error):
+    pass

--- a/lib/automate/pool.py
+++ b/lib/automate/pool.py
@@ -17,6 +17,7 @@ class ModelPool:
 
     Uses non-thread-safe locks!
     """
+
     # Stored as (name, model, lock)
     pool = []
 

--- a/lib/utils/contacts.py
+++ b/lib/utils/contacts.py
@@ -36,8 +36,12 @@ def get_emails(names, sender=None):
             emails.append(name)
             continue
 
-        matches = fuzzy.extract(name, SETTINGS["contacts"].keys())
-        matches = list(filter(lambda x: x[1] > MIN_SCORE, matches))
+        matches = fuzzy.extractBests(name, SETTINGS["contacts"].keys(), score_cutoff=MIN_SCORE)
+        # If the matches contains exact matches, discard the others
+        exact_matches = list(filter(lambda match: match[1] == 100, matches))
+        if len(exact_matches):
+            matches = exact_matches
+
         if len(matches) > 1:
             candidates = []
             for candidate_name, score in matches:

--- a/lib/utils/ner.py
+++ b/lib/utils/ner.py
@@ -2,6 +2,7 @@
 # For English it is recommended to use 'xx_ent_wiki_sm' as the model.
 from fuzzywuzzy import process as fuzzy
 
+
 LABEL_PERSON = "PER"
 MIN_SCORE = 80
 

--- a/lib/utils/ner.py
+++ b/lib/utils/ner.py
@@ -1,5 +1,5 @@
 # Named Entity Recognition utils using a supported spacy model.
-# For English it is recommended to use 'xx_ent_wiki_sm' as the model.
+# For most languages it is recommended to use 'xx_ent_wiki_sm' as the model.
 from fuzzywuzzy import process as fuzzy
 
 
@@ -48,5 +48,4 @@ def cross_check_names(tagged, persons) -> list:
         value, score = fuzzy.extractOne(tag, persons)
         if score > MIN_SCORE and value not in ok:
             ok.append(value)
-
     return ok

--- a/lib/utils/ner.py
+++ b/lib/utils/ner.py
@@ -1,0 +1,51 @@
+# Named Entity Recognition utils using a supported spacy model.
+# For English it is recommended to use 'xx_ent_wiki_sm' as the model.
+from fuzzywuzzy import process as fuzzy
+
+LABEL_PERSON = "PER"
+MIN_SCORE = 80
+
+
+def get_persons(model, text) -> list:
+    """
+    Using the given spacy model, returns a list of all persons in the text.
+    A person can be a full name or an email.
+
+    :param model: The spacy model to use (needs to support NER)
+    :type model: spacy.lang
+    :param text: The sentence to parse names from
+    :type text: str
+    """
+    doc = model(text)
+    persons = []
+
+    for ent in doc.ents:
+        if ent.label_ in [LABEL_PERSON]:
+            persons.append(ent.text)
+
+    for token in doc:
+        if token.like_email and token.text not in persons:
+            persons.append(token.text)
+
+    return persons
+
+
+def cross_check_names(tagged, persons) -> list:
+    """
+    Cross checks a list with tagged names and a list of persons.
+    Uses fuzzywuzzy to see if the tagged names correspond to a name in the
+    persons list. Returns a list of non-duplicated matches.
+
+    :param tagged: List of names that have been tagged by the spacy parser
+    :type tagged: list
+    :param persons: List of persons to match against
+    :type persons: list
+    """
+    ok = []
+
+    for tag in tagged:
+        value, score = fuzzy.extractOne(tag, persons)
+        if score > MIN_SCORE and value not in ok:
+            ok.append(value)
+
+    return ok

--- a/substorm-nlp.yml
+++ b/substorm-nlp.yml
@@ -98,6 +98,7 @@ dependencies:
   - simplejson=3.17.2=py38h1e0a361_1
   - six=1.15.0=py_0
   - spacy=2.3.2=py38hfd86e86_0
+  - spacy-model-en_core_web_md=2.3.1=pyh9f0ad1d_0
   - spacy-model-en_core_web_sm=2.3.1=pyh9f0ad1d_0
   - sqlite=3.33.0=h62c20be_0
   - srsly=1.0.2=py38he6710b0_0

--- a/substorm.sh
+++ b/substorm.sh
@@ -3,16 +3,15 @@ MULTILINE1=$(conda env list | grep -F substorm-nlp)
 
 if [ "$MULTILINE1" = "" ]
 then
-   echo "no conda env found, creating env..."
-   conda env create -f substorm-nlp.yml
+    echo "no conda env found, creating env..."
+    conda env create -f substorm-nlp.yml
 fi
 
 echo "activate conda substorm-nlp env..."
 source ~/anaconda3/etc/profile.d/conda.sh 
 conda activate substorm-nlp
 
-python -m spacy download en_core_web_sm
-python -m spacy download en_core_web_md
+spacy download xx_ent_wiki_sm
 
 MULTILINE2=$(pip list | grep -F en-rpa-simple)
 
@@ -21,8 +20,8 @@ echo "${MULTILINE2}"
 
 if [ "$MULTILINE2" = "" ]
 then
-	echo "missing rpa-models, installing required packages..."
-	pip install -r requirements.txt
-	pwd
+    echo "missing rpa-models, installing required packages..."
+    pip install -r requirements.txt
+    pwd
 fi
 

--- a/tests/automate/modules/reminder/conftest.py
+++ b/tests/automate/modules/reminder/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import sys
 
 from lib.automate.modules.reminder import Reminder
-
+from lib.automate.pool import ModelPool
 
 @pytest.fixture
 def run(monkeypatch):
@@ -13,7 +13,7 @@ def run(monkeypatch):
         pass
 
     def helper(when, body):
-        reminder = Reminder()
+        reminder = Reminder(None)
         # mock the timer used to schedule the reminder
         monkeypatch.setattr("threading.Timer.start", mock_timer_start)
         reminder.prepare_processed(None, when, body, None)
@@ -30,7 +30,7 @@ def notify(monkeypatch):
         called_with.append(popenargs)
 
     def helper(os, body):
-        reminder = Reminder()
+        reminder = Reminder(None)
         monkeypatch.setattr("lib.automate.modules.reminder.run", mock_subprocess_run)
         return reminder.notify(os, body)
 

--- a/tests/automate/modules/reminder/conftest.py
+++ b/tests/automate/modules/reminder/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import sys
 
 from lib.automate.modules.reminder import Reminder
-from lib.automate.pool import ModelPool
+
 
 @pytest.fixture
 def run(monkeypatch):

--- a/tests/automate/modules/send/conftest.py
+++ b/tests/automate/modules/send/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from lib.automate.modules.send import Send
-
+from lib.automate.pool import ModelPool
 
 TEST_SETTINGS = {
     "contacts": {
@@ -32,7 +32,8 @@ TEST_SETTINGS = {
 @pytest.fixture
 def get_test_email(monkeypatch):
     def helper(name):
-        send = Send()
+        pool = ModelPool(["xx_ent_wiki_sm"])
+        send = Send(pool)
         monkeypatch.setattr("lib.automate.modules.send.SETTINGS", TEST_SETTINGS)
         return send.get_email(name)
 

--- a/tests/automate/modules/send/conftest.py
+++ b/tests/automate/modules/send/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 
 from lib.automate.modules.send import Send
-from lib.automate.pool import ModelPool
 
 TEST_SETTINGS = {
     "contacts": {
@@ -32,8 +31,7 @@ TEST_SETTINGS = {
 @pytest.fixture
 def get_test_email(monkeypatch):
     def helper(name):
-        pool = ModelPool(["xx_ent_wiki_sm"])
-        send = Send(pool)
+        send = Send(None)
         monkeypatch.setattr("lib.automate.modules.send.SETTINGS", TEST_SETTINGS)
         return send.get_email(name)
 

--- a/tests/utils/contacts/test_get_emails.py
+++ b/tests/utils/contacts/test_get_emails.py
@@ -36,22 +36,22 @@ class TestGetEmails:
         Test that names that can be connected to multiple contacts returns all
         the candidates as uncertain
         """
-        names = ["hugo", "mark"]
+        names = ["hug", "mark"]
         res = get_emails(names)
 
         assert res["emails"] == ["mark@email.com"]
-        assert res["uncertain"] == [("hugo", [("hugo", "hugo@email.com"), ("hugotwo", "hugotwo@email.com")])]
+        assert res["uncertain"] == [("hug", [("hugotwo", "hugotwo@email.com"), ("hugo", "hugo@email.com")])]
         assert res["unknown"] == []
 
     def test_all(self, four_local_contacts):
         """
         Test that it correctly handles multiple names
         """
-        names = ["hej@gmail.com", "hugo", "aron", "mark", "gustav", "niklas"]
+        names = ["hej@gmail.com", "hug", "aron", "mark", "gustav", "niklas"]
         res = get_emails(names)
 
         assert res["emails"] == ["hej@gmail.com", "mark@email.com", "niklas@email.com"]
-        assert res["uncertain"] == [("hugo", [("hugo", "hugo@email.com"), ("hugotwo", "hugotwo@email.com")])]
+        assert res["uncertain"] == [("hug", [("hugotwo", "hugotwo@email.com"), ("hugo", "hugo@email.com")])]
         assert res["unknown"] == ["aron", "gustav"]
 
     def test_name_is_email(self, four_local_contacts):


### PR DESCRIPTION
# Proposed changes
* Modules will only be initialized once
   * Program will be quicker but might require more memory as modules now stay loaded in memory until program is exited
      * From my own testing it initially required more memory at start but then stayed at the same size unlike the current design where the memory stack keeps growing during use.
   * All verbs/keywords now correspond to a single object instead of a module object for each keyword
* Modules now have access to a shared NLP model pool
   * For NLP models that are used or will be used by many automation modules
   * Keeps memory usage lower as they are shared and only needs to load once
* Name Entity Recognition utilities added, to be able to parse full names from text
  * Only implemented in `send` module but followup still happens (bug?)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Run all with `python lib/cli/cli.py -d DEBUG`

- Open `htop` in a window and then run the program 
   - Run the different modules and multiple times and check that the RES (resident size) doesn't increase for each call to the same module
- `send an email to John Doe` and see that a full name will be parsed from the debug output (but followup still occurs!)
- To check that the modules don't load several times, the easiest way is to add `print(id(self))` in the Module.prepare methods. And see that the id always stays the same for the same module for each call to it

# Related issue
Fixes #115 and fixes #126

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
