### PR TITLE
Add a Speech-to-Text layer which makes it possible for the user to instruct the program using voice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ cython_debug/
 
 # Google API Credentials
 client_secret.json
+service_account.json
 
 # Model folders
 en_rpa_simple/

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ Now the schedule module should work and any created meetings should show up in t
 
 To use the Speech-to-Text feature of the program a Google service account key is required, since it uses the Google [Cloud Speech-to-Text API](https://cloud.google.com/speech-to-text).
 
-With the Cloud Speech-to-Text API [enabled](https://console.cloud.google.com/apis/library/speech.googleapis.com) in your project the key can be created and downloaded as follows
-
 1. Navigate to [Google Cloud Console](https://console.cloud.google.com/apis/) and make sure the correct project is selected.
 2. Go to `credentials`
 3. Click `Create credentials` and select `Service account`
@@ -76,8 +74,7 @@ With the Cloud Speech-to-Text API [enabled](https://console.cloud.google.com/api
 6. When prompted to choose key type select `JSON`
 7. Save the key as `service_account.json`
 8. Move the key into the project folder
-
-**Please note that this Google service is only free for the first 60 minutes of Speech-to-Text processed each month. If you can I recommend starting a [trial account](https://console.cloud.google.com/freetrial/signup/tos) which will give you \$300 free credits.**
+9. [Enable](https://console.cloud.google.com/apis/library/speech.googleapis.com) the Cloud Speech-to-Text API for the same project you created the key for. **Please note that this Google service is only free for the first 60 minutes of Speech-to-Text processed each month. If you can I recommend starting a [trial account](https://console.cloud.google.com/freetrial/signup/tos) which will give you \$300 free credits.**
 
 ## Usage
 
@@ -125,6 +122,7 @@ The CLI should now be running in your terminal. Type `help` for more instruction
 ### GUI
 
 The GUI can be started as follows
+
 - `cd` into the project folder
 - Run `fbs run`
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,36 @@ Since the [schedule module](lib/automate/modules/schedule.py), responsible for s
 for this module to work.
 Follow this [Google guide](https://support.google.com/cloud/answer/6158849?hl=en) and create a Google Calendar API.
 
-The scope of the credentials needs to set to `https://www.googleapis.com/auth/calendar.events.owned`
+The scope of the credentials needs to set to
+
+```
+https://www.googleapis.com/auth/calendar.events.owned
+https://www.googleapis.com/auth/calendar.readonly
+https://www.googleapis.com/auth/contacts.readonly
+https://www.googleapis.com/auth/contacts.other.readonly
+https://www.googleapis.com/auth/directory.readonly
+```
 
 After that download the credentials and put it in `substorm-nlp/` directory, also name it `client_secret.json`.
 
 Now the schedule module should work and any created meetings should show up in the calendar of the account you created the credentials for.
+
+### Google service account
+
+To use the Speech-to-Text feature of the program a Google service account key is required, since it uses the Google [Cloud Speech-to-Text API](https://cloud.google.com/speech-to-text).
+
+With the Cloud Speech-to-Text API [enabled](https://console.cloud.google.com/apis/library/speech.googleapis.com) in your project the key can be created and downloaded as follows
+
+1. Navigate to [Google Cloud Console](https://console.cloud.google.com/apis/) and make sure the correct project is selected.
+2. Go to `credentials`
+3. Click `Create credentials` and select `Service account`
+4. Fill in the required fields, select `Owner` role
+5. Click on the newly created service account, under Keys press `Add key` and select `Create new key`
+6. When prompted to choose key type select `JSON`
+7. Save the key as `service_account.json`
+8. Move the key into the project folder
+
+**Please note that this Google service is only free for the first 60 minutes of Speech-to-Text processed each month. If you can I recommend starting a [trial account](https://console.cloud.google.com/freetrial/signup/tos) which will give you \$300 free credits.**
 
 ## Usage
 

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -31,3 +31,11 @@ class OSNotSupportedError(Error):
 
     def __str__(self):
         return f"{self.message}, os={self.os}"
+
+
+class LanguageNotSupportedError(Error):
+    pass
+
+
+class MissingServiceAccountKeyError(Error):
+    pass

--- a/lib/cli/commands.py
+++ b/lib/cli/commands.py
@@ -4,12 +4,14 @@ The commands available in the CLI
 
 import sys
 import os
+import pyaudio
 from config import config_model_language, choose_version
 
 sys.path.append(".")
 
 from lib.selector.model_installer import Model_Installer  # noqa: E402
 from lib.settings import SETTINGS, get_model_languages, update_settings, get_language_versions  # noqa: E402
+from lib.speech.transcribe import transcribe  # noqa: E402
 
 
 def commands(arr, nlp):
@@ -29,14 +31,23 @@ def commands(arr, nlp):
         language = config_model_language(model_installer.get_languages())
         version = choose_version(model_installer.get_versions(language))
         model_installer.install(language, version)
+    elif arr[0] == "record" or arr[0] == "r":
+        # create audio interface and inform user that the output can be ignored
+        audio_interface = pyaudio.PyAudio()
+        print(
+            "\nIf you see warning messages above they can be ignored. It's caused by PyAudio"
+            + " (used for micrpohone input) and cannot be removed.\n"
+        )
+        print("Recording, please speak...")
+        transcribedInput = transcribe(audio_interface)
+        ans = input(f"This is what I heard:\n    {transcribedInput}\nExecute? [Y/n]: ").lower()
+        if ans == "y" or ans == "yes" or ans == "":
+            run_NLP(transcribedInput, nlp)
+        else:
+            print("Canceled.")
     else:
         text = " ".join(map(str, arr))
-        try:
-            responses = nlp.run(text)
-            for response in responses:
-                print(response + "\n")
-        except Exception as e:
-            print("Failed to execute action.\n", e, file=sys.stderr)
+        run_NLP(text, nlp)
 
 
 def prompt():
@@ -44,3 +55,12 @@ def prompt():
     filename = os.path.join(dirname, "helpprompt.txt")
     f = open(filename, "r")
     print(f.read())
+
+
+def run_NLP(input, nlp):
+    try:
+        responses = nlp.run(input)
+        for response in responses:
+            print(response + "\n")
+    except Exception as e:
+        print("Failed to execute action.\n", e, file=sys.stderr)

--- a/lib/cli/helpprompt.txt
+++ b/lib/cli/helpprompt.txt
@@ -1,8 +1,9 @@
-Program where the user can write instrutions in clear text using machine learning 
-and natural language processing, in order to instruct the computer what to do.
+Program where the user can write instrutions in clear text or record speech in
+order to instruct the computer what to do.
     
 Options:
 exit, e           Exit program.
 help, h           Show this message.
 language, lang    Set the language.
 install, i        Install NLP models.
+record, r         Begin recording of input.

--- a/lib/speech/microphone.py
+++ b/lib/speech/microphone.py
@@ -1,0 +1,62 @@
+"""
+Module for handling a continous stream of micrphone input
+"""
+
+import pyaudio
+from six.moves import queue
+
+# Audio recording configs
+RATE = 16000  # optimal value for the google speech-to-text
+CHUNK = int(RATE / 10)
+
+
+class MicrophoneStream(object):
+    def __init__(self, audio_interface):
+        self.rate = RATE
+        self.chunk = CHUNK
+        self.buffer = queue.Queue()
+        self.closed = True
+        self.audio_interface = audio_interface
+
+    def __enter__(self):
+        self.audo_stream = self.audio_interface.open(
+            format=pyaudio.paInt16,
+            channels=1,  # google api can only handle 1 channel audio
+            rate=self.rate,
+            input=True,
+            frames_per_buffer=self.chunk,
+            stream_callback=self.buffer_push,
+        )
+        self.closed = False
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.audo_stream.stop_stream()
+        self.audo_stream.close()
+        self.closed = True
+        self.buffer.put(None)  # stop signal
+        self.audio_interface.terminate()
+
+    # Unused arguments because it's required when used as PyAudio stream_callback
+    def buffer_push(self, data, frame_count, time_info, status_flags):
+        self.buffer.put(data)
+        return None, pyaudio.paContinue
+
+    def generator(self):
+        while not self.closed:
+            chunk = self.buffer.get()  # blocking get
+            if chunk is None:
+                return
+            data = [chunk]
+
+            # empty queue of chunks
+            while True:
+                try:
+                    chunk = self.buffer.get(block=False)
+                    if chunk is None:
+                        return
+                    data.append(chunk)
+                except queue.Empty:
+                    break  # wait for more input
+
+            yield b"".join(data)

--- a/lib/speech/transcribe.py
+++ b/lib/speech/transcribe.py
@@ -1,0 +1,55 @@
+"""
+Module for transcribing speech input using the google speech-to-text api (see
+https://cloud.google.com/speech-to-text)
+"""
+
+import os
+
+from google.cloud import speech
+
+from lib import LanguageNotSupportedError, MissingServiceAccountKeyError
+from lib.settings import SETTINGS, load_user
+
+from .microphone import RATE, MicrophoneStream
+
+
+def transcribe(audio_interface):
+    """
+    Transcribes a stream of microphone input using google cloud speech to
+    convert speech to text.
+
+    Takes a audio_interface (pyaudio.PyAudio()) as an argument because calling
+    it produces output and the user needs to be informed that this is not a
+    problem with this program from the caller of this function.
+    """
+    load_user()
+    user_lang = SETTINGS["user"]["language"]
+    if user_lang == "english":
+        lang = "en-US"
+    else:
+        # The Google API support other languages but our models currently only work with English
+        raise LanguageNotSupportedError(
+            f"Speech-to-text is not supported for the current language ({user_lang}), please change the language to"
+            + "English"
+        )
+
+    # Setup google cloud speech
+    if not os.path.isfile("service_account.json"):
+        raise MissingServiceAccountKeyError(
+            "Required Google service account key does not exist. Speech-to-text does not work without it."
+        )
+    client = speech.SpeechClient.from_service_account_json("service_account.json")
+    config = speech.RecognitionConfig(
+        encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16, sample_rate_hertz=RATE, language_code=lang
+    )
+    streaming_config = speech.StreamingRecognitionConfig(config=config, interim_results=False)
+
+    with MicrophoneStream(audio_interface) as stream:
+        # Transcribe one sentence of microphone stream input
+        audio_generator = stream.generator()
+        requests = (speech.StreamingRecognizeRequest(audio_content=content) for content in audio_generator)
+        responses = client.streaming_recognize(streaming_config, requests)
+
+    # Return the transcribed sentence
+    for response in responses:
+        return response.results[0].alternatives[0].transcript

--- a/substorm-nlp-win.yml
+++ b/substorm-nlp-win.yml
@@ -9,7 +9,7 @@ dependencies:
   - brotlipy=0.7.0=py38he774522_1000
   - ca-certificates=2020.10.14=0
   - catalogue=1.0.0=py38_1
-  - certifi=2020.6.20=py38_0
+  - certifi=2020.6.20=pyhd3eb1b0_3
   - cffi=1.14.3=py38h7a1dbc1_0
   - chardet=3.0.4=py38_1003
   - click=7.1.2=py_0
@@ -35,7 +35,9 @@ dependencies:
   - pathspec=0.7.0=py_0
   - pip=20.2.4=py38_0
   - plac=0.9.6=py38_1
+  - portaudio=19.6.0=he774522_4
   - preshed=3.0.2=py38h33f27b4_1
+  - pyaudio=0.2.11=py38he774522_2
   - pycodestyle=2.6.0=py_0
   - pycparser=2.20=py_2
   - pyflakes=2.2.0=py_0
@@ -43,6 +45,7 @@ dependencies:
   - pyrsistent=0.17.3=py38he774522_0
   - pysocks=1.7.1=py38_0
   - python=3.8.5=h5fd99cc_1
+  - pyyaml=5.3.1=py38he774522_1
   - regex=2020.10.15=py38he774522_0
   - requests=2.24.0=py_0
   - setuptools=50.3.0=py38h9490d1a_1
@@ -55,6 +58,7 @@ dependencies:
   - tqdm=4.50.2=py_0
   - typed-ast=1.4.1=py38he774522_0
   - typing_extensions=3.7.4.3=py_0
+  - tzlocal=2.1=py38_0
   - urllib3=1.25.11=py_0
   - vc=14.1=h0510ff6_4
   - vs2015_runtime=14.16.27012=hf0eaf9b_3
@@ -62,16 +66,46 @@ dependencies:
   - wheel=0.35.1=py_0
   - win_inet_pton=1.1.0=py38_0
   - wincertstore=0.2=py38_0
+  - yaml=0.2.5=he774522_0
   - zipp=3.3.1=py_0
   - zlib=1.2.11=h62dcd97_4
   - pip:
     - altgraph==0.17
+    - beautifulsoup4==4.9.3
+    - cachetools==4.1.1
     - fbs==0.9.0
     - future==0.18.2
+    - fuzzywuzzy==0.18.0
+    - google==3.0.0
+    - google-api-client==3.14.159265359.post1
+    - google-api-core==1.23.0
+    - google-api-python-client==1.12.8
+    - google-auth==1.23.0
+    - google-auth-httplib2==0.0.4
+    - google-auth-oauthlib==0.4.2
+    - google-cloud-speech==2.0.1
+    - googleapis-common-protos==1.52.0
+    - grpcio==1.33.2
+    - httplib2==0.18.1
+    - libcst==0.3.14
     - macholib==1.14
+    - oauthlib==3.1.0
     - pefile==2019.4.18
+    - proto-plus==1.11.0
+    - protobuf==3.14.0
+    - pyasn1==0.4.8
+    - pyasn1-modules==0.2.8
     - pyinstaller==3.4
     - pyqt5==5.15.1
     - pyqt5-sip==12.8.1
+    - python-levenshtein==0.12.0
+    - pytz==2020.4
     - pywin32-ctypes==0.2.0
+    - requests-oauthlib==1.3.0
+    - rsa==4.6
+    - soupsieve==2.0.1
+    - typing-inspect==0.6.0
+    - uritemplate==3.0.1
+    - word2number==1.1
 prefix: C:\Users\alexa\anaconda3\envs\substorm-nlp-win
+

--- a/substorm-nlp.yml
+++ b/substorm-nlp.yml
@@ -68,11 +68,13 @@ dependencies:
   - pip=20.2.2=py38_0
   - plac=0.9.6=py38_1
   - pluggy=0.13.1=py38h32f6830_3
+  - portaudio=19.6.0=h7b6447c_4
   - preshed=3.0.2=py38he6710b0_1
   - protobuf=3.13.0.1=py38h950e882_1
   - py=1.9.0=pyh9f0ad1d_0
   - pyasn1=0.4.8=py_0
   - pyasn1-modules=0.2.7=py_0
+  - pyaudio=0.2.11=py38h7b6447c_2
   - pycodestyle=2.6.0=py_0
   - pycparser=2.20=py_2
   - pyflakes=2.2.0=py_0
@@ -121,13 +123,18 @@ dependencies:
   - zipp=3.1.0=py_0
   - zlib=1.2.11=h7b6447c_3
   - pip:
-    - altgraph==0.17
-    - caldav==0.7.1
-    - fbs==0.9.0
-    - future==0.18.2
-    - macholib==1.14
-    - pefile==2019.4.18
-    - pyinstaller==3.4
-    - pyqt5==5.15.1
-    - pyqt5-sip==12.8.1
+      - altgraph==0.17
+      - caldav==0.7.1
+      - fbs==0.9.0
+      - future==0.18.2
+      - macholib==1.14
+      - pefile==2019.4.18
+      - pyinstaller==3.4
+      - pyqt5==5.15.1
+      - pyqt5-sip==12.8.1
+      - google-cloud-speech==2.0.0
+      - grpcio==1.33.2
+      - libcst==0.3.13
+      - proto-plus==1.11.0
+      - typing-inspect==0.6.0
 prefix: /home/user/anaconda3/envs/substorm-nlp

--- a/tests/speech/conftest.py
+++ b/tests/speech/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+from lib.speech.transcribe import transcribe
+
+
+@pytest.fixture
+def user_with_non_supported_lang(monkeypatch):
+    _non_supported_lang = {"user": {"email": None, "language": "swedish", "language_version": None, "name": None}}
+    monkeypatch.setattr("lib.speech.transcribe.SETTINGS", _non_supported_lang)
+
+
+@pytest.fixture
+def transcribe_no_key(monkeypatch):
+    def mock_isfile(path):
+        return False
+
+    def helper():
+        monkeypatch.setattr("lib.speech.transcribe.os.path.isfile", mock_isfile)
+        return transcribe(None)
+
+    yield helper

--- a/tests/speech/test_transcribe.py
+++ b/tests/speech/test_transcribe.py
@@ -1,0 +1,21 @@
+"""
+Module that tests the exception handling of the transcribe function
+"""
+import pytest
+
+from lib.speech.transcribe import LanguageNotSupportedError, MissingServiceAccountKeyError, transcribe
+
+
+class TestTranscribe:
+    """Tests for the exceptions in the transcribe function"""
+
+    def test_language_not_supported(self, user_with_non_supported_lang):
+        """Test that an exception is raised when the user has a non-supported language"""
+        with pytest.raises(LanguageNotSupportedError) as excinfo:
+            transcribe(None)
+        assert "not supported for the current language" in str(excinfo.value)
+
+    def test_missing_service_account_key(self, transcribe_no_key):
+        with pytest.raises(MissingServiceAccountKeyError) as excinfo:
+            transcribe_no_key()
+        assert "key does not exist" in str(excinfo.value)


### PR DESCRIPTION
# Proposed changes
* Adds functionality for reading a continuous stream of microphone input 
* Adds a function which will use the Google Cloud Speech-to-Text API to transcribe one sentence (until the user stops speaking for a certain time) and returns the interpreted text
* Adds an `r` or `record` command to the CLI which will ask the user to instruct the computer using voice. This is basically the same as the original text input just that the voice is transcribed to text before invoking the NLP module. The user is asked to confirm that the transcribed text is correct before the task is executed.

Please check out [this](https://github.com/rpa-tomorrow/substorm-nlp/blob/127-stt-layer/README.md#google-service-account) README section for how to setup a service account which is needed for the Speech-to-Text API to work. Note the bold text about this not being an entirely free service.

# How Has This Been Tested?
Since the actual procedure of executing the input has not changed all of the automation functionality should be left unchanged. The added functionality has been tested using the CLI `r`command. Unittests has also been written for the two exceptions in `transcribe.py` (Language not supported and missing service account key).

The microphone stream has only been tested on Linux but the implementation uses `PyAudio` which I assume works well on Windows as well but it would be nice if @Aleman778 could confirm this.
- [x] Microphone works on Linux
- [x] Microphone works on Windows 10 

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- With the CLI running issuing `r` command will record voice until the user stops speaking. The user should then be shown the interpreted sentence and asked for confirmation before the task is executed.

# Related issue
Closes #127, please see issue #144 (schedule module does not work well with Speech-to-Text since it doesn't understand am/pm). 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
