### PR TITLE
Change CLI library and make CLI more intuitive

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length=120
+ignore=W503

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          $CONDA/bin/flake8 . --count --ignore=N --select=E9,F63,F7,F82 --show-source --statistics
+          $CONDA/bin/flake8 . --count --ignore=N,W503 --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          $CONDA/bin/flake8 . --count --ignore=N --max-line-length=120 --statistics
+          $CONDA/bin/flake8 . --count --ignore=N,W503 --max-line-length=120 --statistics
       - name: Test with pytest
         run: |
           $CONDA/bin/pytest

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          $CONDA/bin/flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          $CONDA/bin/flake8 . --count --ignore=N --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          $CONDA/bin/flake8 . --count --max-line-length=120 --statistics
+          $CONDA/bin/flake8 . --count --ignore=N --max-line-length=120 --statistics
       - name: Test with pytest
         run: |
           $CONDA/bin/pytest

--- a/lib/cli/cli.py
+++ b/lib/cli/cli.py
@@ -18,8 +18,9 @@ def cli(debug, verbose):
     spin = spinner.Spinner()
     load_prerequisites(spin, debug, verbose)
     n = load_selector(spin)
-    click.secho("\nType any task(s) and the robot will start working on it:", bold=True)
 
+    click.secho("\nType any task(s) and the robot will start working on it", bold=True)
+    click.secho("(or type 'help' to display all options):", bold=True)
     try:
         while True:
             txt = click.prompt("", prompt_suffix="> ").strip()

--- a/lib/cli/cli.py
+++ b/lib/cli/cli.py
@@ -1,15 +1,81 @@
-import plac
-import sys
 import commands
 import logging
 import spinner
 import warnings
+import click
 
 from config import load_settings_from_cli
 from lib.selector.selector import ModuleSelector  # noqa: E402
 
 
-def setup_logger(level):
+@click.command()
+@click.option("--verbose", "-v", "verbose", is_flag=True, help="Enable verbose output")
+@click.option("--debug", "-d", "debug", help="Set the debug logging level which will be output")
+def cli(debug, verbose):
+    click.clear()
+    click.secho("RPA Tomorrow - managing tasks from natural text", fg="green", bold=True)
+
+    spin = spinner.Spinner()
+    load_prerequisites(spin, debug, verbose)
+    n = load_selector(spin)
+    click.secho("\nType any task(s) and the robot will start working on it:", bold=True)
+
+    try:
+        while True:
+            txt = click.prompt("", prompt_suffix="> ").strip()
+
+            if txt == "":
+                continue
+            else:
+                txt_arr = txt.split(" ")
+                commands.commands(txt_arr, n)
+    except Exception:
+        click.secho("\nGood bye!", fg="green", bold=True)
+        click.clear()
+
+
+def load_prerequisites(spinner, debug, verbose):
+    click.secho("· Loading settings... ", bold=True)
+    with spinner:
+        load_settings_from_cli()
+    print("", end="\x1b[1K\r")
+    click.secho("---> DONE", fg="green", bold=True)
+
+    click.secho("· Waking up the robot... ", bold=True)
+    with spinner:
+        setup_logger(debug, verbose)
+    print("", end="\x1b[1K\r")
+    click.secho("---> DONE", fg="green", bold=True)
+
+
+def load_selector(spinner):
+    click.secho("· Loading models... ", bold=True)
+    with spinner:
+        n = ModuleSelector()
+    print("", end="\x1b[1K\r")
+    click.secho("---> DONE", fg="green", bold=True)
+    click.secho("· Natural language processing ready!", bold=True)
+
+    return n
+
+
+def setup_logger(debug, verbose):
+    try:
+        if debug is not None and verbose:
+            click.echo("[WARNING]: Verbose and debug output are both enabled. Ignoring verbose flag!", err=True)
+
+        if debug is not None:
+            init_logger(debug)
+        elif verbose:
+            init_logger(logging.INFO)
+        else:
+            init_logger(logging.WARNING)
+    except ValueError:
+        init_logger(logging.WARNING)
+        click.echo("[WARNING]: Could not parse debug flag. Using default log settings.", err=True)
+
+
+def init_logger(level):
     # create logger
     logger = logging.getLogger()
     logger.setLevel(level)
@@ -28,42 +94,10 @@ def setup_logger(level):
     logger.addHandler(ch)
 
 
-@plac.annotations(
-    debug=("Set the debug logging level which will be output", "option", "d", str),
-    verbose=("Enable verbose output", "flag", "v"),
-)
-def cli(debug, verbose):
-    try:
-        if debug is not None and verbose:
-            print("WARNING: Verbose and debug output are both enabled. Ignoring verbose flag!")
-
-        if debug is not None:
-            setup_logger(debug)
-        elif verbose:
-            setup_logger(logging.INFO)
-        else:
-            setup_logger(logging.WARNING)
-    except ValueError:
-        setup_logger(logging.WARNING)
-        print("WARNING: Could not parse debug flag. Using default log settings.")
-
-    spin = spinner.Spinner()
-    spin.set_message("Loading settings and nlp models...")
-    with spin:
-        load_settings_from_cli()
-        n = ModuleSelector()
-        print("\nNatural language processing ready!")
-
-    while True:
-        txt = sys.stdin.readline().strip()
-
-        if txt == "":
-            continue
-        else:
-            txt_arr = txt.split(" ")
-            commands.commands(txt_arr, n)
+def supress_warnings():
+    warnings.filterwarnings("ignore", message=r"\[W008\]", category=UserWarning)
 
 
 if __name__ == "__main__":
-    warnings.filterwarnings("ignore", message=r"\[W008\]", category=UserWarning)
-    plac.call(cli)
+    supress_warnings()
+    cli()

--- a/lib/cli/cli.py
+++ b/lib/cli/cli.py
@@ -3,6 +3,7 @@ import sys
 import commands
 import logging
 import spinner
+import warnings
 
 from config import load_settings_from_cli
 from lib.selector.selector import ModuleSelector  # noqa: E402
@@ -64,4 +65,5 @@ def cli(debug, verbose):
 
 
 if __name__ == "__main__":
+    warnings.filterwarnings("ignore", message=r"\[W008\]", category=UserWarning)
     plac.call(cli)

--- a/lib/cli/commands.py
+++ b/lib/cli/commands.py
@@ -5,6 +5,7 @@ The commands available in the CLI
 import sys
 import os
 import pyaudio
+import click
 from config import config_model_language, choose_version
 
 sys.path.append(".")
@@ -14,14 +15,16 @@ from lib.settings import SETTINGS, get_model_languages, update_settings, get_lan
 from lib.speech.transcribe import transcribe  # noqa: E402
 
 
-def commands(arr, nlp):
+def commands(arr, selector):
     """
     Commands supported by the CLI
     """
     if arr[0] == "exit" or arr[0] == "e":
+        click.secho("\nGood bye!", fg="green", bold=True)
+        click.clear()
         sys.exit()
     elif arr[0] == "help" or arr[0] == "h":
-        prompt()
+        help_output()
     elif arr[0] == "language" or arr[0] == "lang":
         SETTINGS["user"]["language"] = config_model_language(get_model_languages())
         SETTINGS["user"]["language_version"] = choose_version(get_language_versions(SETTINGS["user"]["language"]))
@@ -34,33 +37,34 @@ def commands(arr, nlp):
     elif arr[0] == "record" or arr[0] == "r":
         # create audio interface and inform user that the output can be ignored
         audio_interface = pyaudio.PyAudio()
-        print(
+        click.echo(
             "\nIf you see warning messages above they can be ignored. It's caused by PyAudio"
             + " (used for micrpohone input) and cannot be removed.\n"
         )
-        print("Recording, please speak...")
-        transcribedInput = transcribe(audio_interface)
-        ans = input(f"This is what I heard:\n    {transcribedInput}\nExecute? [Y/n]: ").lower()
+        click.echo("Recording, please speak...")
+        transcribed_input = transcribe(audio_interface)
+        audio_interface.terminate()
+        ans = input(f"This is what I heard:\n    {transcribed_input}\nExecute? [Y/n]: ").lower()
         if ans == "y" or ans == "yes" or ans == "":
-            run_NLP(transcribedInput, nlp)
+            run_selector(transcribed_input, selector)
         else:
-            print("Canceled.")
+            click.echo("Canceled.")
     else:
         text = " ".join(map(str, arr))
-        run_NLP(text, nlp)
+        run_selector(text, selector)
 
 
-def prompt():
+def help_output():
     dirname = os.path.dirname(__file__)
     filename = os.path.join(dirname, "helpprompt.txt")
     f = open(filename, "r")
     print(f.read())
 
 
-def run_NLP(input, nlp):
+def run_selector(input, selector):
     try:
-        responses = nlp.run(input)
+        responses = selector.run(input)
         for response in responses:
-            print(response + "\n")
+            click.echo(response + "\n")
     except Exception as e:
         print("Failed to execute action.\n", e, file=sys.stderr)

--- a/lib/cli/spinner.py
+++ b/lib/cli/spinner.py
@@ -20,14 +20,14 @@ class Spinner:
             self.delay = delay
 
     def spinner_task(self):
-        print(self.custom_message)
+        if self.custom_message:
+            print(self.custom_message)
         while self.busy:
             sys.stdout.write("---" + next(self.spinner_generator))
             sys.stdout.flush()
             time.sleep(self.delay)
             sys.stdout.write("\b")
             sys.stdout.flush()
-        print("\n")
 
     def __enter__(self):
         self.busy = True

--- a/lib/selector/selector.py
+++ b/lib/selector/selector.py
@@ -13,6 +13,9 @@ FMT_ALLOWED_CHARS = r"[^a-zA-Z0-9.'@\-: ]"
 # Module logger
 log = logging.getLogger(__name__)
 
+# Module logger
+log = logging.getLogger(__name__)
+
 
 class ModuleSelector:
     def __init__(self):
@@ -25,6 +28,7 @@ class ModuleSelector:
 
     def _check_similarities(self, word, verbs):
         doc_verb = self.general_model(word)
+        log.debug("VERBS: %s", verbs)
         for verb in verbs:
             doc_action = self.general_model(verb)
             similarity = doc_action.similarity(doc_verb)

--- a/lib/selector/selector.py
+++ b/lib/selector/selector.py
@@ -13,9 +13,6 @@ FMT_ALLOWED_CHARS = r"[^a-zA-Z0-9.'@\-: ]"
 # Module logger
 log = logging.getLogger(__name__)
 
-# Module logger
-log = logging.getLogger(__name__)
-
 
 class ModuleSelector:
     def __init__(self):
@@ -28,7 +25,6 @@ class ModuleSelector:
 
     def _check_similarities(self, word, verbs):
         doc_verb = self.general_model(word)
-        log.debug("VERBS: %s", verbs)
         for verb in verbs:
             doc_action = self.general_model(verb)
             similarity = doc_action.similarity(doc_verb)

--- a/substorm-nlp.yml
+++ b/substorm-nlp.yml
@@ -12,18 +12,22 @@ dependencies:
   - blas=1.0=mkl
   - blinker=1.4=py_1
   - brotlipy=0.7.0=py38h7b6447c_1000
-  - ca-certificates=2020.10.14=0
+  - ca-certificates=2020.11.8=ha878542_0
   - cachetools=4.1.1=py_0
   - catalogue=1.0.0=py38_1
-  - certifi=2020.6.20=pyhd3eb1b0_3
+  - certifi=2020.11.8=py38h578d9bd_0
   - cffi=1.14.3=py38he30daa8_0
   - chardet=3.0.4=py38_1003
   - click=7.1.2=py_0
+  - colorama=0.4.4=py_0
+  - commonmark=0.9.1=py_0
   - coverage=5.3=py38h1e0a361_1
   - cryptography=3.1.1=py38h1ba5d50_0
   - cymem=2.0.3=py38he6710b0_0
   - cython-blis=0.4.1=py38h7b6447c_1
   - flake8=3.8.3=py_0
+  - flake8-polyfill=1.0.2=py38_0
+  - future=0.18.2=py38h578d9bd_2
   - fuzzywuzzy=0.17.0=py_0
   - google-api-core=1.23.0=pyh9f0ad1d_0
   - google-api-python-client=1.12.4=pyh9f0ad1d_0
@@ -62,11 +66,11 @@ dependencies:
   - numpy=1.19.1=py38hbc911f0_0
   - numpy-base=1.19.1=py38hfa32c7d_0
   - oauthlib=3.0.1=py_0
-  - openssl=1.1.1h=h7b6447c_0
+  - openssl=1.1.1h=h516909a_0
   - packaging=20.4=pyh9f0ad1d_0
   - pathspec=0.7.0=py_0
+  - pep8-naming=0.11.1=py38_0
   - pip=20.2.2=py38_0
-  - plac=0.9.6=py38_1
   - pluggy=0.13.1=py38h32f6830_3
   - portaudio=19.6.0=h7b6447c_4
   - preshed=3.0.2=py38he6710b0_1
@@ -78,6 +82,7 @@ dependencies:
   - pycodestyle=2.6.0=py_0
   - pycparser=2.20=py_2
   - pyflakes=2.2.0=py_0
+  - pygments=2.7.2=py_0
   - pyjwt=1.7.1=py_0
   - pyopenssl=19.1.0=py_1
   - pyparsing=2.4.7=pyh9f0ad1d_0
@@ -88,6 +93,7 @@ dependencies:
   - python=3.8.5=h7579374_1
   - python-dateutil=2.8.1=py_0
   - python-levenshtein=0.12.0=py38h1e0a361_1001
+  - python-sounddevice=0.4.1=pyh9f0ad1d_0
   - python_abi=3.8=1_cp38
   - pytz=2020.1=pyh9f0ad1d_0
   - pyyaml=5.3.1=py38h8df0ef7_1
@@ -123,18 +129,16 @@ dependencies:
   - zipp=3.1.0=py_0
   - zlib=1.2.11=h7b6447c_3
   - pip:
-      - altgraph==0.17
-      - caldav==0.7.1
-      - fbs==0.9.0
-      - future==0.18.2
-      - macholib==1.14
-      - pefile==2019.4.18
-      - pyinstaller==3.4
-      - pyqt5==5.15.1
-      - pyqt5-sip==12.8.1
-      - google-cloud-speech==2.0.0
-      - grpcio==1.33.2
-      - libcst==0.3.13
-      - proto-plus==1.11.0
-      - typing-inspect==0.6.0
-prefix: /home/user/anaconda3/envs/substorm-nlp
+    - altgraph==0.17
+    - caldav==0.7.1
+    - fbs==0.9.0
+    - google-cloud-speech==2.0.0
+    - grpcio==1.33.2
+    - libcst==0.3.13
+    - macholib==1.14
+    - pefile==2019.4.18
+    - proto-plus==1.11.0
+    - pyinstaller==3.4
+    - pyqt5==5.15.1
+    - pyqt5-sip==12.8.1
+    - typing-inspect==0.6.0


### PR DESCRIPTION
# Proposed changes
Major
* Change CLI library from `plac` to `click` which supports a lot more features and works flawlessly on Windows
* Add some color output
* Give user some helpful instructions after loading models is finished

Minor
* Rename `nlp` to `selector` in CLI code
* Add pep8-naming plugin to check naming conventions with flake8 (helpful but optional!)
* Ignore naming convention on Github workflows checks as it is optional

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

With `python lib/cli/cli.py`
- Tested and displays correctly on both Linux and Windows

# Related issue
n/a

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
