### PR TITLE
156 remove meeting

### DIFF
--- a/lib/automate/google.py
+++ b/lib/automate/google.py
@@ -110,7 +110,12 @@ class Calendar:
         Does not return past events that has already ended
         """
         now = dt.now()
-        return self.service.events().list(calendarId="primary", timeMin=(now.isoformat() + "Z")).execute()["items"]
+        events = (
+            self.service.events()
+            .list(calendarId="primary", timeMin=(now.astimezone(now.tzinfo).isoformat()))
+            .execute()["items"]
+        )
+        return events
 
     def delete_event(self, eventId: str):
         self.service.events().delete(calendarId="primary", eventId=eventId).execute()

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -154,7 +154,7 @@ class RemoveSchedule(Module):
         for token in doc:
             if token.dep_ == "TO":
                 to.append(token.text)
-            elif token.dep_ == "WHEN":
+            elif token.dep_ == "START":
                 when.append(token.text)
             elif token.dep_ == "BODY":
                 body.append(token.text)

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -117,7 +117,7 @@ class RemoveSchedule(Module):
         """ """
         if self.followup_type == "self_busy":
             # if the user answers "yes" on the followup question then remove the event from the calendar
-            if answer.lower() in ["y", "yes"]:
+            if answer.lower() in ["y", "yes", ""]:
                 return None
             else:
                 raise ActionInterruptedByUserError("Event Not removed.")


### PR DESCRIPTION
# Proposed changes
* Fix removal of meetings by both timestamp and summary

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- Create a meeting at a time during the current hour, if it is 10:20 then create a meeting at 10:30
    - input `remove meeting at 10:30`, you should be prompted about removing the newly created meeting
- Create  a meeting with a summary `test`
    - input `remove meeting about test`, you should be prompted about removing the newly created meeting

# Related issue
Fixes #156 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
