### PR TITLE
Simplify ModelPool usage and automatically lock/unlock lock

### DIFF
--- a/lib/automate/modules/send.py
+++ b/lib/automate/modules/send.py
@@ -3,15 +3,12 @@ import spacy
 import lib.utils.tools.time_convert as tc
 import logging
 import lib.utils.ner as ner
-import asyncio
 
 from email.message import EmailMessage
-
 from lib.automate.modules import Module, NoSenderError
 from lib import Error
 from lib.settings import SETTINGS
 from datetime import datetime, timedelta
-
 from lib.utils.contacts import get_emails, prompt_contact_choice, NoContactFoundError, followup_contact_choice
 
 # Module logger

--- a/lib/automate/modules/send.py
+++ b/lib/automate/modules/send.py
@@ -134,12 +134,15 @@ class Send(Module):
         Lets the reminder model work on the given text.
         """
         doc = self.nlp_model(text)
-        ner_model = asyncio.run(self.model_pool.acquire_model("xx_ent_wiki_sm"))
 
         to = []
         when = []
         body = []
-        persons = ner.get_persons(ner_model, text)
+        persons = []
+
+        locked_ner_model = self.model_pool.get_shared_model("xx_ent_wiki_sm")
+        with locked_ner_model:
+            persons = ner.get_persons(locked_ner_model.acquire_model(), text)
 
         for token in doc:
             if token.dep_ == "TO":
@@ -161,7 +164,6 @@ class Send(Module):
 
         _body = " ".join(body)
 
-        self.model_pool.release_model(ner_model)
         return (to, time, _body)
 
 

--- a/lib/automate/pool.py
+++ b/lib/automate/pool.py
@@ -1,5 +1,5 @@
 import spacy
-import asyncio
+import threading
 import logging
 
 from lib import Error
@@ -8,60 +8,94 @@ from lib import Error
 log = logging.getLogger(__name__)
 
 
+class SharedModel:
+    """
+    SharedModel is a wrapper around a preloaded spacy model
+    that locks the model when in use and unlocks after it has
+    been used. Multiple references can exist to the SharedModel, but
+    only one request to use it is allowed at a time.
+
+    Usage:
+    The recommended usage is with in a `with` statement. If an
+    exception occurs the model will be automatically unlocked. E.g.
+    ```
+    s = SharedModel("en_core_web_sm", "en_core_web_sm")
+    with s:
+        # Locks when calling the code below
+        model = s.get_model()
+    # SharedModel is unlocked here even during exception
+
+    ```
+    """
+    def __init__(self, name, model):
+        self._name = name
+        self._model = model
+        self._lock = threading.Lock()
+
+    def __enter__(self):
+        log.debug("Waiting to acquire lock for model %s", self._name)
+        self._lock.acquire()
+        log.debug("Acquired lock for model %s", self._name)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._lock.release()
+        log.debug("Released lock for model %s", self._name)
+
+    def name(self):
+        return self._name
+
+    def acquire_model(self):
+        """
+        acquire_model returns whatever spacy model that
+        the SharedModel contains.
+        :return Spacy model
+        """
+        return self._model
+
+
 class ModelPool:
     """
-    ModelPool contains a pool of spacy models to be shared between
-    different automation modules. When a model is acquired a lock will
-    be put on it such that no other modules can use it. When a lock is released
-    the model can be used by the next module that is requesting it.
+    ModelPool contains a pool of SharedModels (spacy model wrappers) to be
+    shared between different automation modules. When a SharedModel is acquired
+    it will return a reference to that object. When calling methods to the
+    SharedModel object it will be locked and unlocked automatically. If the
+    SharedModel is locked when trying to use it, the call will be blocked until
+    the object is unlocked.
 
-    Uses non-thread-safe locks!
+    Uses thread-safe locks.
     """
 
-    # Stored as (name, model, lock)
-    pool = []
+    # Pool of objects with type SharedModel
+    pool = dict()
 
     def __init__(self, model_names):
         """
         From the given model names, loads the models into memory, in the shared
-        model pool.
-        :param shared_models: Names of the spacy models to be shared.
+        model pool as SharedModels.
+        :param model_names: Names of the spacy models to be shared.
         :type list[string]
         """
         for name in model_names:
             model = spacy.load(name)
-            lock = asyncio.Lock()
-            self.pool.append((name, model, lock))
+            self.pool[name] = SharedModel(name, model)
         log.debug("Initialized shared models in pool")
 
-    async def acquire_model(self, model_name):
+    def get_shared_model(self, model_name):
         """
-        Acquires a spacy model in the model pool. If the model is already in
-        use, it will wait until the model is released, lock it and then return
-        the model. If the model is not found, an exception will be raised.
+        Acquires a SharedModel in the model pool. Once acquired there is
+        no need to return the SharedModel, as the SharedModel object will
+        be automatically locked/unlocked when in use/not in use. If the model
+        is not found, a NoModelFoundError exception will be raised.
+
         :param model_name: The name of the spacy model to acquire.
         :type model_name: string
-        :return: The spacy model
+        :return: The shared model
+        :rtype: SharedModel
         """
-        for name, model, lock in self.pool:
-            if name == model_name:
-                log.debug("Waiting to acquire lock for model %s", name)
-                await lock.acquire()
-                log.debug("Acquired lock for model %s", name)
-                return model
+        if model_name in self.pool:
+            return self.pool[model_name]
 
         raise NoModelFoundError("No model by the name %s found", model_name)
-
-    def release_model(self, model):
-        """
-        Relases the lock for a model such that others can use it.
-        :param model_name: The name of the spacy model to release.
-        :type model_name: string
-        """
-        for name, shared_model, lock in self.pool:
-            if model == shared_model:
-                lock.release()
-                log.debug("Released lock for model %s", name)
 
 
 class NoModelFoundError(Error):

--- a/lib/automate/pool.py
+++ b/lib/automate/pool.py
@@ -20,10 +20,10 @@ class SharedModel:
     exception occurs the model will be automatically unlocked. E.g.
     ```
     s = SharedModel("en_core_web_sm", "en_core_web_sm")
+    # `s` Locks when calling the code below
     with s:
-        # Locks when calling the code below
-        model = s.get_model()
-    # SharedModel is unlocked here even during exception
+        model = s.acquire_model()
+    # `s` is unlocked here even during exception
 
     ```
     """

--- a/lib/automate/pool.py
+++ b/lib/automate/pool.py
@@ -27,6 +27,7 @@ class SharedModel:
 
     ```
     """
+
     def __init__(self, name, model):
         self._name = name
         self._model = model

--- a/tests/automate/pool/conftest.py
+++ b/tests/automate/pool/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from lib.automate.pool import ModelPool, SharedModel
+
+
+@pytest.fixture
+def empty_pool():
+    return ModelPool([])
+
+
+@pytest.fixture
+def init_pool():
+    yield ModelPool
+
+
+@pytest.fixture
+def init_shared_model():
+    yield SharedModel

--- a/tests/automate/pool/test_pool.py
+++ b/tests/automate/pool/test_pool.py
@@ -1,0 +1,9 @@
+import pytest
+
+from lib.automate.pool import NoModelFoundError
+
+
+class TestPool:
+    def test_not_found_exception(self, empty_pool):
+        with pytest.raises(NoModelFoundError):
+            empty_pool.get_shared_model("unknown")

--- a/tests/automate/pool/test_sharedmodel.py
+++ b/tests/automate/pool/test_sharedmodel.py
@@ -1,0 +1,35 @@
+import time
+import threading
+
+
+def acquire_and_keep(s):
+    with s:
+        time.sleep(1)
+
+
+class TestSharedModel:
+    def test_wait_if_locked(self, init_shared_model):
+        """
+        Check if a thread has to wait if the model in
+        already in use.
+        """
+        s = init_shared_model("TEST", "TEST")
+
+        t1 = threading.Thread(target=acquire_and_keep, args=s)
+        t2 = threading.Thread(target=acquire_and_keep, args=s)
+        t1.start()
+        t2.start()
+        assert t2.is_alive()
+
+    def test_acquire_after_unlocked(self, init_shared_model):
+        """
+        Check if the model can be acquired after it's been
+        unlocked.
+        """
+        s = init_shared_model("TEST", "TEST")
+
+        t1 = threading.Thread(target=acquire_and_keep, args=s)
+        t1.start()
+        model = s.acquire_model()
+
+        assert model == "TEST"


### PR DESCRIPTION
# Proposed changes
* New data structure `SharedModel` that wraps around a spacy model together with a mutex lock
* `SharedModels` can be fetched from the `ModelPool`
* When using a spacy model from `SharedModel` it will be automatically locked/unlocked
* Example usage:
```python
m = ModelPool(["en_core_web_sm"])
s = m.get_shared_model("en_core_web_sm")

# Locks SharedModel here
with s:
    # Use spacy model here freely
    spacy_model = s.acquire_model()
   
# SharedModel is unlocked here even after an exception
```

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

Unit test:
- First use SharedModel on one thread, then try to use it on another thread (should block)
- First use SharedModel on one thread, finish job, then try to use it on another thread (should access immediately)

Manual testing:
- Add prints id of the models accessed inside `send` module and check that after each usage of this module, the id stays the same. Which means that the model has not been reloaded. (Of course removed before PR)

# Related issue
Fixes #152 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
