### PR TITLE
Add selector and use case tests

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -22,6 +22,10 @@ jobs:
         run: |
           # $CONDA is an environment variable pointing to the root of the miniconda directory
           $CONDA/bin/conda env update --file substorm-nlp.yml --name base
+      - name: Install models for tests
+        run: |
+          $CONDA/bin/python -m spacy download xx_ent_wiki_sm
+          $CONDA/bin/pip install -r requirements.txt
       - name: Format using black
         run: |
           $CONDA/bin/black --check . --diff --line-length=120

--- a/substorm-nlp.yml
+++ b/substorm-nlp.yml
@@ -129,16 +129,16 @@ dependencies:
   - zipp=3.1.0=py_0
   - zlib=1.2.11=h7b6447c_3
   - pip:
-    - altgraph==0.17
-    - caldav==0.7.1
-    - fbs==0.9.0
-    - google-cloud-speech==2.0.0
-    - grpcio==1.33.2
-    - libcst==0.3.13
-    - macholib==1.14
-    - pefile==2019.4.18
-    - proto-plus==1.11.0
-    - pyinstaller==3.4
-    - pyqt5==5.15.1
-    - pyqt5-sip==12.8.1
-    - typing-inspect==0.6.0
+      - altgraph==0.17
+      - caldav==0.7.1
+      - fbs==0.9.0
+      - google-cloud-speech==2.0.0
+      - grpcio==1.33.2
+      - libcst==0.3.13
+      - macholib==1.14
+      - pefile==2019.4.18
+      - proto-plus==1.11.0
+      - pyinstaller==3.4
+      - pyqt5==5.15.1
+      - pyqt5-sip==12.8.1
+      - typing-inspect==0.6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,105 @@
 import sys
+import pytest
 
 # This solves an issue with not being able to import modules from the lib/
 # folder in the test files
 sys.path.append(".")
 sys.path.append("..")
+
+
+@pytest.fixture(scope="session", autouse=False)
+def monkeymodule():
+    """
+    Fixture that makes it possible to use monkeypatch in another session scoped
+    fixture
+    """
+    from _pytest.monkeypatch import MonkeyPatch
+
+    mp = MonkeyPatch()
+    yield mp
+    mp.undo()
+
+
+@pytest.fixture
+def user_with_config():
+    """
+    A mocked user with complete config, the yielded dictionary will have
+    to be monkeypatched into your test to work.
+
+    Example:
+    mocking SETTINGS in lib.automate.modules.schedule is done by adding
+    monkeypatch.setattr(
+        "lib.automate.modules.schedule.SETTINGS",
+        user_with_config
+    )
+    before the Schedule object is created and yielded
+    """
+    user = {
+        "email": {
+            "address": "johndoe@email.com",
+            "host": "localhost",
+            "password": "mypass",
+            "port": None,
+            "ssl": False,
+            "username": "johndoe@email.com",
+        },
+        "language": "english",
+        "language_version": "0.0.1",
+        "name": "John Doe",
+    }
+    nlp_models = {
+        "basic": "en_rpa_simple",
+        "email": "en_rpa_simple_email",
+        "reminder": "en_rpa_simple_reminder",
+        "schedule": "en_rpa_simple_calendar",
+        "spacy_md": "en_core_web_md",
+        "spacy_sm": "en_core_web_sm",
+        "ner": "xx_ent_wiki_sm",
+    }
+    meeting = {"standard_duration": 15}
+    contacts = {
+        "Hugo Wangler": {"email": {"address": "hugo@email.com"}},
+        "Niklas": {"email": {"address": "niklas@email.com"}},
+        "Viktor": {"email": {"address": "viktor@email.com"}},
+        "Mark": {"email": {"address": "mark@email.com"}},
+        "Aron": {"email": {"address": "aron@email.com"}},
+        "Alexander": {"email": {"address": "alexander@email.com"}},
+    }
+    yield {"user": user, "nlp_models": nlp_models, "meeting": meeting, "contacts": contacts}
+
+
+@pytest.fixture(scope="session", autouse=False)
+def session_user_with_config():
+    """ Fixture needed when mocking settings in session scoped fixtures """
+    user = {
+        "email": {
+            "address": "johndoe@email.com",
+            "host": "localhost",
+            "password": "mypass",
+            "port": None,
+            "ssl": False,
+            "username": "johndoe@email.com",
+        },
+        "language": "english",
+        "language_version": "0.0.1",
+        "name": "John Doe",
+    }
+    nlp_models = {
+        "basic": "en_rpa_simple",
+        "email": "en_rpa_simple_email",
+        "reminder": "en_rpa_simple_reminder",
+        "schedule": "en_rpa_simple_calendar",
+        "spacy_md": "en_core_web_md",
+        "spacy_sm": "en_core_web_sm",
+        "ner": "xx_ent_wiki_sm",
+    }
+    meeting = {"standard_duration": 15}
+    contacts = {
+        "Hugo Wangler": {"email": {"address": "hugo@email.com"}},
+        "Niklas": {"email": {"address": "niklas@email.com"}},
+        "Viktor": {"email": {"address": "viktor@email.com"}},
+        "Mark": {"email": {"address": "mark@email.com"}},
+        "Aron": {"email": {"address": "aron@email.com"}},
+        "Alexander": {"email": {"address": "alexander@email.com"}},
+    }
+    yield {"user": user, "nlp_models": nlp_models, "meeting": meeting, "contacts": contacts}

--- a/tests/selector/conftest.py
+++ b/tests/selector/conftest.py
@@ -1,0 +1,66 @@
+import pytest
+
+from lib.selector.selector import ModuleSelector
+
+
+@pytest.fixture(scope="session", autouse=False)
+def selector(monkeymodule, session_user_with_config):
+    """
+    Yields a module selector
+
+    This fixture will only be executed once since the scope is
+    session, this prevents having to load the models for every test.
+    """
+
+    # mock settings everywhere
+    monkeymodule.setattr("lib.selector.selector.SETTINGS", session_user_with_config)
+    monkeymodule.setattr("lib.automate.SETTINGS", session_user_with_config)
+    monkeymodule.setattr("lib.automate.modules.schedule.SETTINGS", session_user_with_config)
+    selector = ModuleSelector()
+    yield selector
+
+
+@pytest.fixture
+def no_automate(monkeypatch):
+    """
+    Fixture that just returns the processed text instead of sending it to the
+    automation module for execution
+    """
+
+    def mock_send_automate(self, verb, text):
+        return {"verb": verb, "text": text}
+
+    monkeypatch.setattr("lib.selector.selector.ModuleSelector._send_automate", mock_send_automate)
+
+
+class MockTask:
+    """
+    A mocked task which has an execute function that just returns a response
+    """
+
+    def execute(self):
+        """ The mocked response """
+        return "this is a response"
+
+
+@pytest.fixture
+def mock_task_execute(monkeypatch):
+    """
+    Fixture that will mock the execute function of the prepared tasks
+    """
+
+    def mock_send_automate(self, verb, text):
+        mock = MockTask()
+        return mock
+
+    monkeypatch.setattr("lib.selector.selector.ModuleSelector._send_automate", mock_send_automate)
+
+
+@pytest.fixture
+def example_tasks():
+    reminder_task = "remind me to eat in 30 seconds"
+    schedule_task = "schedule a meeting with Mark at 15:00"
+    email_task = "send an email to John saying hello mate"
+    remove_task = "remove the meeting at 15:00"
+
+    yield {"remind": reminder_task, "schedule": schedule_task, "send": email_task, "remove": remove_task}

--- a/tests/selector/test_prepare.py
+++ b/tests/selector/test_prepare.py
@@ -1,0 +1,47 @@
+"""
+Module that tests the task preparation done on input
+"""
+
+
+class TestPrepare:
+    """Tests for the preparation of input text"""
+
+    def test_invalid_task(self, selector):
+        """Test that an invalid task in the input is handled"""
+        task = selector.prepare("hjasdalsdkjaslk jdlasjdalksjdak jkasljdajs")
+        assert len(task) == 1
+        assert task[0] is None
+
+    def test_remind_task(self, selector, no_automate, example_tasks):
+        """Test that a reminder task can be prepared"""
+        task = selector.prepare(example_tasks["remind"])
+        assert len(task) == 1
+        assert task[0]["verb"] == "remind"
+
+    def test_schedule_task(self, selector, no_automate, example_tasks):
+        """Test that a schedule task can be prepared"""
+        task = selector.prepare(example_tasks["schedule"])
+        assert len(task) == 1
+        assert task[0]["verb"] == "schedule"
+
+    def test_send_task(self, selector, no_automate, example_tasks):
+        """Test that a send task can be prepared"""
+        task = selector.prepare(example_tasks["send"])
+        assert len(task) == 1
+        assert task[0]["verb"] == "send"
+
+    def test_remove_task(self, selector, no_automate, example_tasks):
+        """Test that a remove scheduled event task can be prepared"""
+        task = selector.prepare(example_tasks["remove"])
+        assert len(task) == 1
+        assert task[0]["verb"] == "remove"
+
+    def test_multiple_tasks(self, selector, no_automate, example_tasks):
+        """Test that multiple tasks in the input can be prepared"""
+        multiple_tasks_input = ". ".join(task for task in example_tasks.values())
+        tasks = selector.prepare(multiple_tasks_input)
+        assert len(tasks) == len(example_tasks)
+        assert tasks[0]["verb"] == "remind"
+        assert tasks[1]["verb"] == "schedule"
+        assert tasks[2]["verb"] == "send"
+        assert tasks[3]["verb"] == "remove"

--- a/tests/selector/test_selector_run.py
+++ b/tests/selector/test_selector_run.py
@@ -1,0 +1,40 @@
+"""
+Module testing the running of tasks
+"""
+
+
+class TestRun:
+    """ Tests that supported tasks can be run from the selector module """
+
+    def test_invalid_task(self, selector):
+        """
+        Test that an invalid task will return something indicating that
+        it is invalid.
+        """
+        response = selector.run("jashdkjsahd kjashdkjashdkjashd jahs kdh")
+        assert len(response) == 1
+        assert response[0] == "I did not understand"
+
+    def test_valid_task(self, mock_task_execute, selector, example_tasks):
+        """ Test that a valid task will return a response after execution """
+        response = selector.run(example_tasks["remind"])
+        assert len(response) == 1
+        assert response[0] == "this is a response"
+
+    def test_multiple_tasks(self, mock_task_execute, selector, example_tasks):
+        """ Test that multiple tasks result in a response from each task """
+        multiple_tasks_input = ". ".join(task for task in example_tasks.values())
+        response = selector.run(multiple_tasks_input)
+        assert len(response) == len(example_tasks)
+        assert (r is not None for r in response)
+
+    def test_multiple_tasks_mixed(self, mock_task_execute, selector, example_tasks):
+        """
+        Test that a mix of valid and invalid tasks will return a response
+        from each executed task
+        """
+        multiple_tasks_input = ". ".join(task for task in example_tasks.values())
+        multiple_tasks_input += "asjdasd kjaskdjas askjdkj"
+        response = selector.run(multiple_tasks_input)
+        assert len(response) == len(example_tasks)
+        assert (r is not None for r in response)

--- a/tests/selector/use_cases/conftest.py
+++ b/tests/selector/use_cases/conftest.py
@@ -1,0 +1,134 @@
+import pytest
+from datetime import datetime, timedelta
+
+
+class CalendarMock:
+    """
+    A calendar mock where event creation just returns the parameters of the
+    event
+    """
+
+    def __init__(self, settings):
+        self.settings = settings
+
+    def event(self, start, end, attendees, body):
+        """ Returns the parameters of the event """
+        return {"start": start, "end": end, "attendees": attendees, "body": body}
+
+    def get_events(self):
+        """ Returns a list of events in the mocked calendar """
+        start_time_1 = datetime.now() + timedelta(hours=1.0)
+        end_time_1 = datetime.now() + timedelta(hours=2.0)
+        start_time_2 = datetime.now() + timedelta(hours=5.0)
+        end_time_2 = datetime.now() + timedelta(hours=7.0)
+
+        return [
+            {
+                "summary": "test",
+                "attendees": [{"email": "niklas@email.com"}],
+                "start": {"date": start_time_1.isoformat(), "dateTime": start_time_1.time()},
+                "end": {"date": end_time_1.isoformat(), "dateTime": end_time_1.time()},
+            },
+            {
+                "summary": "another one",
+                "attendees": [{"email": "hugo@email.com"}],
+                "start": {"date": start_time_2.isoformat(), "dateTime": start_time_2.time()},
+                "end": {"date": end_time_2.isoformat(), "dateTime": end_time_2.time()},
+            },
+        ]
+
+
+class CalendarNeverBusyMock(CalendarMock):
+    """ Mock of a calendar where the user or attendees will never be busy """
+
+    def __init__(self, settings):
+        super().__init__(settings)
+
+    def freebusy(self, start, end, attendees_email):
+        """ Returns empty list to simulate no other meetings during time """
+        return []
+
+
+class GoogleMock:
+    def __init__(self, username):
+        self.username = username
+
+    def calendar(self, settings):
+        return CalendarMock(settings)
+
+
+class GoogleNeverBusyMock(GoogleMock):
+    def __init__(self, username):
+        super().__init__(username)
+
+    def calendar(self, settings):
+        return CalendarNeverBusyMock(settings)
+
+
+@pytest.fixture
+def calendar_not_busy(monkeypatch):
+    def mock_execute(self):
+        return self.event
+
+    monkeypatch.setattr("lib.automate.modules.schedule.Google", GoogleNeverBusyMock)
+    monkeypatch.setattr("lib.automate.modules.schedule.Schedule.execute", mock_execute)
+
+
+@pytest.fixture
+def send_email(monkeypatch):
+    """
+    Fixture mocking the send email functionality to just return the email
+    information instead of sending smtp
+    """
+
+    def mock_send_email(self, settings, receiver, subject, content):
+        return {"settings": settings, "receiver": receiver, "subject": subject, "content": content}
+
+    monkeypatch.setattr("lib.automate.modules.send.Send.send_email", mock_send_email)
+
+
+@pytest.fixture
+def calendar_with_events(monkeypatch):
+    """
+    Fixture that mocks the google calendar object in remove schedule. The
+    calendar has some predefined events that will be returned upon calling
+    get_events.
+    """
+
+    def mock_prompt_remove_event(self):
+        """ Dont ask user for confirmation to delete during test """
+        pass
+
+    monkeypatch.setattr("lib.automate.modules.remove_schedule.Google", GoogleMock)
+    monkeypatch.setattr(
+        "lib.automate.modules.remove_schedule.RemoveSchedule.prompt_remove_event", mock_prompt_remove_event
+    )
+
+
+@pytest.fixture
+def automate_no_handle_response(monkeypatch, user_with_config):
+    """
+    Fixture that simply returns the response instead of asking for input from
+    the user
+    """
+
+    def mock_prepare(self, module_name, text):
+        print("in mock prepare")
+        sender = user_with_config["user"]
+        instance = self._load_module(module_name)
+        return instance.prepare(user_with_config["nlp_models"], text, sender)
+
+    monkeypatch.setattr("lib.automate.Automate.prepare", mock_prepare)
+
+
+@pytest.fixture
+def remove_schedule_no_execute(monkeypatch):
+    """
+    Fixture that makes the remove schedule execute function just return
+    the event that will be deleted
+    """
+
+    def mock_execute(self):
+        return self.event
+
+    monkeypatch.setattr("lib.automate.modules.remove_schedule.RemoveSchedule.execute", mock_execute)

--- a/tests/selector/use_cases/test_remove_schedule.py
+++ b/tests/selector/use_cases/test_remove_schedule.py
@@ -1,0 +1,71 @@
+"""
+Module testing that the use case remove scheduled event can be executed correctly
+"""
+from datetime import datetime, timedelta
+
+
+class TestUseCaseRemoveSchedule:
+    """
+    Tests that a valid input for the remove scheduled meeting results in a response
+    """
+
+    def test_remove_by_summary(self, selector, calendar_with_events, remove_schedule_no_execute):
+        """
+        Tests that removing a meeeting by specifying the summary removes
+        the correct event
+        """
+        task_text = "remove the meeting about test"
+        response = selector.run(task_text)
+        assert len(response) == 1
+        removed = response[0]
+
+        # should remove the event with the correct summary
+        assert removed["summary"] == "test"
+
+    def test_remove_by_timestamp(self, selector, calendar_with_events, remove_schedule_no_execute):
+        """
+        Tests that removing a meeting by specifying the time of the meeting
+        removes the correct event
+
+        The meetings in the mock have one starting now() + 1hr (1hr duration)
+        and one starting now + 5hr (2hr duration)
+        """
+        # remove meeting starting now + 1hr
+        time_meeting = datetime.now() + timedelta(hours=1.5)
+        time_meeting_input = str(time_meeting.time())[0:5]  # convert to HH:MM
+        task_text = f"remove the meeting at {time_meeting_input}"
+        response = selector.run(task_text)
+        assert len(response) == 1
+        removed = response[0]
+
+        # should remove the meeting which occurs during the specified time
+        removed_start = datetime.fromisoformat(removed["start"]["date"])
+        removed_end = datetime.fromisoformat(removed["end"]["date"])
+        assert removed_start <= time_meeting and removed_end >= time_meeting
+
+        # remove meeting starting now + 5hr
+        time_meeting = datetime.now() + timedelta(hours=6)
+        time_meeting_input = str(time_meeting.time())[0:5]  # convert to HH:MM
+        task_text = f"remove the meeting at {time_meeting_input}"
+        response = selector.run(task_text)
+        assert len(response) == 1
+        removed = response[0]
+
+        # should remove the meeting which occurs during the specified time
+        removed_start = datetime.fromisoformat(removed["start"]["date"])
+        removed_end = datetime.fromisoformat(removed["end"]["date"])
+        assert removed_start <= time_meeting and removed_end >= time_meeting
+
+    def test_remove_by_participants(self, selector, calendar_with_events, remove_schedule_no_execute):
+        """
+        Tests that removing a meeting by specfifying the pariticipants of the
+        meeting removes the correct event.
+
+        The meetings in the mock have one meeting with Hugo and one with Niklas.
+        """
+        task_text = "remove the meeting with Hugo"
+        response = selector.run(task_text)
+        assert len(response) == 1
+        removed = response[0]
+
+        assert "hugo@email.com" in list(a["email"] for a in removed["attendees"])

--- a/tests/selector/use_cases/test_schedule.py
+++ b/tests/selector/use_cases/test_schedule.py
@@ -1,0 +1,36 @@
+"""
+Module testing that the use case schedule can be executed correctly
+"""
+
+
+class TestUseCaseSchedule:
+    """
+    Tests that valid input for the schedule use case will result in a response
+    """
+
+    def test_schedule_basic(self, selector, calendar_not_busy, user_with_config):
+        """
+        Test that a schedule task with only a starting time will be executed
+        """
+        task_text = "schedule a meeting with hello@email.com at 10:00 about test"
+        response = selector.run(task_text)
+        assert len(response) == 1
+        event = response[0]
+
+        # The event should have correct starting time and duration
+        assert event["start"].strftime("%H:%M") == "10:00"
+        assert event["end"].strftime("%H:%M") == f"10:{user_with_config['meeting']['standard_duration']}"
+        assert "hello@email.com" in event["attendees"]
+
+    def test_schedule_interval(self, selector, calendar_not_busy):
+        """
+        Test that a schedule task with both a start and end time will be executed
+        """
+        task_text = "schedule a meeting at 12:00 to 15:00 with hello@email.com about test"
+        response = selector.run(task_text)
+        assert len(response) == 1
+        event = response[0]
+
+        assert event["start"].strftime("%H:%M") == "12:00"
+        assert event["end"].strftime("%H:%M") == "15:00"
+        assert "hello@email.com" in event["attendees"]

--- a/tests/selector/use_cases/test_send_email.py
+++ b/tests/selector/use_cases/test_send_email.py
@@ -1,0 +1,33 @@
+"""
+Module testing that the use case email can be executed correctly
+"""
+
+
+class TestUseCaseEmail:
+    """
+    Tests that valid input for the email use case results in a respones
+    """
+
+    def test_email_receiver_address(self, selector, send_email):
+        """ Test that an email can be sent using the full address of the receiver """
+        task_text = "send an email to hej@email.com about how is it going?"
+        response = selector.run(task_text)
+        assert len(response) == 1
+        email = response[0]
+
+        assert len(email["receiver"]) == 1
+        assert "hej@email.com" in email["receiver"]
+        # should include a signature
+        assert "Regards,\nJohn Doe" in email["content"]
+
+    def test_email_receiver_name(self, selector, send_email, user_with_config):
+        """ Test that an email can be sent using the name of the receiver """
+        task_text = "send an email to Hugo about hello there"
+        response = selector.run(task_text)
+        assert len(response) == 1
+        email = response[0]
+
+        assert len(email["receiver"]) == 1
+        assert user_with_config["contacts"]["Hugo Wangler"]["email"]["address"] in email["receiver"]
+        # should include a signature
+        assert "Regards,\nJohn Doe" in email["content"]


### PR DESCRIPTION
# Proposed changes
- Added tests for the selector. These tests try to confirm that our module
selector can, given certain input, select each of our models.

- Added tests for use cases send email, schedule meeting and remove
meeting. These tests do not test any followup logic only checks that the
use case can be executed with our current models etc.

Hopefully this will help us detect some regression in the future.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- pytest

# Related issue
Fixes #160 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
