### PR TITLE
Creates a followup object

### DIFF
--- a/lib/automate/__init__.py
+++ b/lib/automate/__init__.py
@@ -76,8 +76,7 @@ class Automate:
 
         def handle_response(response):
             if response:
-                print(response, end=": ", flush=True)
-                return handle_response(instance.followup(input()))
+                return handle_response(response.handle_cli())
             else:
                 return instance
 
@@ -85,9 +84,8 @@ class Automate:
 
         followup = instance.prepare(SETTINGS["nlp_models"], text, sender)
         if self.response_callback:
-            return self.response_callback(instance, followup)
-        else:
-            return handle_response(followup)
+            return self.response_callback(instance, followup.question)
+        return handle_response(followup)
 
 
 class NoResponseError(Error):

--- a/lib/automate/followup.py
+++ b/lib/automate/followup.py
@@ -1,0 +1,80 @@
+from lib import NotImplementedError
+
+
+class Followup:
+    type = None
+    question = None
+
+    def handle_cli(self):
+        raise NotImplementedError("Method not implemented")
+
+
+class MultiFollowup(Followup):
+    def __init__(self, question: str, options: [(str, str)], callback, enable_none: bool):
+        self.question = question
+        self.answer = None
+        self.options = options
+        self.callback = callback
+        self.enable_none = enable_none
+
+    def handle_cli(self):
+        followup_str = f"{self.question}\n"
+        for i, (_, text) in enumerate(self.options):
+            followup_str += f"[{i+1}] {text}\n"
+        followup_str += f"\n[0] None of the above \nPlease choose one (0-{len(self.options)})"
+
+        print(followup_str, end=": ", flush=True)
+        input_str = input()
+
+        try:
+            choice = int(input_str) - 1
+        except Exception:
+            return self.handle_cli()
+        if choice < -1 or choice >= len(self.options):
+            return self.handle_cli()
+        self.answer = self.options[choice][0]
+        return self.callback(self)
+
+
+class StringFollowup(Followup):
+    def __init__(self, question: str, callback, default_answer: str = None):
+        self.question = question
+        self.callback = callback
+        self.answer = default_answer
+        self.default_answer = default_answer
+
+    def handle_cli(self):
+        print(self.question, end=": ", flush=True)
+        input_str = input()
+        if input_str:
+            self.answer = input_str
+        elif self.default_answer is None:
+            return self.handle_cli()
+        return self.callback(self)
+
+
+class BooleanFollowup(Followup):
+    def __init__(self, question: str, callback, default_answer: bool = None):
+        self.question = question
+        self.callback = callback
+        self.answer = default_answer
+        self.default_answer = default_answer
+
+    def handle_cli(self):
+        if self.default_answer is None:
+            end = " [y/n]:"
+        elif self.default_answer:
+            end = " [Y/n]:"
+        else:
+            end = " [y/N]:"
+        print(self.question, end=end, flush=True)
+        input_str = input()
+        if input_str == "" and self.default_answer is not None:
+            self.answer = self.default_answer
+        elif input_str.lower() in ["y", "yes"]:
+            self.answer = True
+        elif input_str.lower() in ["n", "no"]:
+            self.answer = False
+        else:
+            return self.handle_cli()
+        return self.callback(self)

--- a/lib/automate/followup.py
+++ b/lib/automate/followup.py
@@ -14,7 +14,8 @@ class MultiFollowup(Followup):
         self.question = question
         self.answer = None
         self.options = options
-        self.callback = callback
+        self.callback_ = callback
+        self.callback = lambda: self.callback_(self)
         self.enable_none = enable_none
 
     def handle_cli(self):
@@ -33,13 +34,14 @@ class MultiFollowup(Followup):
         if choice < -1 or choice >= len(self.options):
             return self.handle_cli()
         self.answer = self.options[choice][0]
-        return self.callback(self)
+        return self.callback()
 
 
 class StringFollowup(Followup):
     def __init__(self, question: str, callback, default_answer: str = None):
         self.question = question
-        self.callback = callback
+        self.callback_ = callback
+        self.callback = lambda: self.callback_(self)
         self.answer = default_answer
         self.default_answer = default_answer
 
@@ -50,13 +52,14 @@ class StringFollowup(Followup):
             self.answer = input_str
         elif self.default_answer is None:
             return self.handle_cli()
-        return self.callback(self)
+        return self.callback()
 
 
 class BooleanFollowup(Followup):
     def __init__(self, question: str, callback, default_answer: bool = None):
         self.question = question
-        self.callback = callback
+        self.callback_ = callback
+        self.callback = lambda: self.callback_(self)
         self.answer = default_answer
         self.default_answer = default_answer
 
@@ -77,4 +80,4 @@ class BooleanFollowup(Followup):
             self.answer = False
         else:
             return self.handle_cli()
-        return self.callback(self)
+        return self.callback()

--- a/lib/automate/modules/reminder.py
+++ b/lib/automate/modules/reminder.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from threading import Timer
 from subprocess import run
 from lib import OSNotSupportedError, TimeIsInPastError
+from lib.automate.followup import StringFollowup
 from lib.automate.modules import Module
 
 
@@ -73,11 +74,26 @@ class Reminder(Module):
         self.followup_type = None
 
         if not isinstance(when, datetime):
-            self.followup_type = "when"
-            return "\nCould not parse date to schedule to.\nPlease enter date in YYYYMMDD HH:MM format"
+
+            def callback(followup):
+                try:
+                    when = datetime.fromisoformat(followup.answer)
+                except Exception:
+                    when = None
+                return self.prepare_processed(self.to, when, self.body, self.sender)
+
+            question = "\nCould not parse date to schedule to.\nPlease enter date in YYYYMMDD HH:MM format"
+            followup = StringFollowup(question, callback)
+            return followup
+
         elif not body:
-            self.followup_type = "body"
-            return "\nFound no message body. What message should be sent"
+
+            def callback(followup):
+                return self.prepare_processed(self.to, self.when, followup.answer, self.sender)
+
+            question = "\nFound no message body. What message should be sent"
+            followup = StringFollowup(question, callback)
+            return followup
 
         when_delta = (when - datetime.now()).total_seconds()  # convert to difference in seconds
         if when_delta < 0.0:
@@ -99,23 +115,6 @@ class Reminder(Module):
     def execute(self):
         self.timer.start()
         return f"\nReminder scheduled for {self.when.strftime('%Y-%m-%d %H:%M:%S')}"
-
-    def followup(self, answer: str) -> (str, str):
-        """
-        Follow up method after the module have had to ask a question to clarify some parameter, or just
-        want to check that it interpreted everything correctly.
-        """
-        if self.followup_type == "when":
-            try:
-                when = datetime.fromisoformat(answer)
-            except Exception:
-                when = None
-            return self.prepare_processed(self.to, when, self.body, self.sender)
-
-        elif self.followup_type == "body":
-            return self.prepare_processed(self.to, self.when, answer, self.sender)
-        else:
-            raise NotImplementedError("Did not find any valid followup question to answer.")
 
     def nlp(self, text):
         """

--- a/lib/automate/modules/reminder.py
+++ b/lib/automate/modules/reminder.py
@@ -74,26 +74,9 @@ class Reminder(Module):
         self.followup_type = None
 
         if not isinstance(when, datetime):
-
-            def callback(followup):
-                try:
-                    when = datetime.fromisoformat(followup.answer)
-                except Exception:
-                    when = None
-                return self.prepare_processed(self.to, when, self.body, self.sender)
-
-            question = "\nCould not parse date to schedule to.\nPlease enter date in YYYYMMDD HH:MM format"
-            followup = StringFollowup(question, callback)
-            return followup
-
+            return self.prompt_date()
         elif not body:
-
-            def callback(followup):
-                return self.prepare_processed(self.to, self.when, followup.answer, self.sender)
-
-            question = "\nFound no message body. What message should be sent"
-            followup = StringFollowup(question, callback)
-            return followup
+            return self.prompt_body()
 
         when_delta = (when - datetime.now()).total_seconds()  # convert to difference in seconds
         if when_delta < 0.0:
@@ -144,3 +127,23 @@ class Reminder(Module):
         _body = " ".join(body)
 
         return (to, time, _body)
+
+    def prompt_date(self):
+        def callback(followup):
+            try:
+                when = datetime.fromisoformat(followup.answer)
+            except Exception:
+                when = None
+            return self.prepare_processed(self.to, when, self.body, self.sender)
+
+        question = "\nCould not parse date to schedule to.\nPlease enter date in YYYYMMDD HH:MM format"
+        followup = StringFollowup(question, callback)
+        return followup
+
+    def prompt_body(self):
+        def callback(followup):
+            return self.prepare_processed(self.to, self.when, followup.answer, self.sender)
+
+        question = "\nFound no message body. What message should be sent"
+        followup = StringFollowup(question, callback)
+        return followup

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -102,7 +102,7 @@ class RemoveSchedule(Module):
             start_time = event["start"]["dateTime"]
             start_time = datetime.fromisoformat(start_time)
             formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
-            alternatives.append((event, f"{event['summary']} at {formated_time}\n"))
+            alternatives.append((event, f"{event['summary']} at {formated_time}"))
 
         followup = MultiFollowup(followup_str, alternatives, callback, True)
         return followup

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -4,12 +4,13 @@ import spacy
 import lib.utils.ner as ner
 
 from lib import Error
+from lib.automate.followup import BooleanFollowup, MultiFollowup
 from lib.utils import contacts
 from lib.automate.google import Google
 from lib.automate.modules import Module
 import lib.utils.tools.time_convert as tc
 from datetime import datetime, timedelta
-from lib.utils.contacts import prompt_contact_choice, followup_contact_choice
+from lib.utils.contacts import prompt_contact_choice
 
 log = logging.getLogger(__name__)
 
@@ -71,8 +72,7 @@ class RemoveSchedule(Module):
                 attendees.append(email)
             for (name, candidates) in parsed_attendees["uncertain"]:
                 self.uncertain_attendee = (name, candidates)
-                self.followup_type = "to_uncertain"
-                return prompt_contact_choice(name, candidates)
+                return prompt_contact_choice(name, candidates, self)
 
             contacts.get_emails(self.to)
 
@@ -82,18 +82,24 @@ class RemoveSchedule(Module):
         if len(self.events) == 1:
             self.event = self.events[0]
         elif len(self.events) > 1:
-            self.followup_type = "to_many_events"
+
+            def callback(followup):
+                if followup.answer is not None:
+                    self.event = followup.answer
+                    return self.prepare_processed(self.to, self.when, self.body, self.sender)
+                else:
+                    raise NoEventFoundError("\nNo event was chosen for deletion")
 
             followup_str = "Found multiple events: \n"
-            for n in range(len(self.events)):
-                event = self.events[n]
+            alternatives = []
+            for event in self.events:
                 start_time = event["start"]["dateTime"]
                 start_time = datetime.fromisoformat(start_time)
                 formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
-                followup_str += f"[{n+1}] {event['summary']} at {formated_time}\n"
-            followup_str += f"\n[0] None of the above \nPlease choose one (0-{len(self.events)})"
+                alternatives.append((event, f"{event['summary']} at {formated_time}\n"))
 
-            return followup_str
+            followup = MultiFollowup(followup_str, alternatives, callback, True)
+            return followup
         else:
             raise NoEventFoundError("\nCould not find an event.")
 
@@ -105,36 +111,18 @@ class RemoveSchedule(Module):
         start_time = datetime.fromisoformat(start_time)
         formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
 
-        self.followup_type = "self_busy"
-        return (
-            f"\nYou have the event '{self.event['summary']}' scheduled at {formated_time}.\n"
-            "Do you want to remove it? [Y/n]"
-        )
-
-    def followup(self, answer):
-        """ """
-        if self.followup_type == "self_busy":
-            # if the user answers "yes" on the followup question then remove the event from the calendar
-            if answer.lower() in ["y", "yes", ""]:
+        def callback(followup):
+            if followup.answer:
                 return None
             else:
                 raise ActionInterruptedByUserError("Event Not removed.")
-        elif self.followup_type == "to_uncertain":
-            return followup_contact_choice(self, answer)
-        elif self.followup_type == "to_many_events":
-            try:
-                choice = int(answer) - 1
-            except Exception:
-                return self.prepare_processed(self.to, self.when, self.body, self.sender)
 
-            if choice < 0:
-                raise NoEventFoundError("\nNo event was chosen for deletion")
-
-            elif choice >= 0 and choice < len(self.events):
-                self.event = self.events[choice]
-                return self.prepare_processed(self.to, self.when, self.body, self.sender)
-        else:
-            raise NotImplementedError("")
+        question = (
+            f"\nYou have the event '{self.event['summary']}' scheduled at {formated_time}.\n"
+            "Do you want to remove it?"
+        )
+        followup = BooleanFollowup(question, callback, default_answer=True)
+        return followup
 
     def execute(self):
         self.calendar.delete_event(self.event["id"])

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -82,28 +82,30 @@ class RemoveSchedule(Module):
         if len(self.events) == 1:
             self.event = self.events[0]
         elif len(self.events) > 1:
-
-            def callback(followup):
-                if followup.answer is not None:
-                    self.event = followup.answer
-                    return self.prepare_processed(self.to, self.when, self.body, self.sender)
-                else:
-                    raise NoEventFoundError("\nNo event was chosen for deletion")
-
-            followup_str = "Found multiple events: \n"
-            alternatives = []
-            for event in self.events:
-                start_time = event["start"]["dateTime"]
-                start_time = datetime.fromisoformat(start_time)
-                formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
-                alternatives.append((event, f"{event['summary']} at {formated_time}\n"))
-
-            followup = MultiFollowup(followup_str, alternatives, callback, True)
-            return followup
+            return self.prompt_multiple()
         else:
             raise NoEventFoundError("\nCould not find an event.")
 
         return self.prompt_remove_event()
+
+    def prompt_multiple(self):
+        def callback(followup):
+            if followup.answer is not None:
+                self.event = followup.answer
+                return self.prepare_processed(self.to, self.when, self.body, self.sender)
+            else:
+                raise NoEventFoundError("\nNo event was chosen for deletion")
+
+        followup_str = "Found multiple events: \n"
+        alternatives = []
+        for event in self.events:
+            start_time = event["start"]["dateTime"]
+            start_time = datetime.fromisoformat(start_time)
+            formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
+            alternatives.append((event, f"{event['summary']} at {formated_time}\n"))
+
+        followup = MultiFollowup(followup_str, alternatives, callback, True)
+        return followup
 
     def prompt_remove_event(self):
         """ Prompt the user about deleting an event"""

--- a/lib/automate/modules/send.py
+++ b/lib/automate/modules/send.py
@@ -47,26 +47,11 @@ class Send(Module):
         self.content = body + f"\n\nRegards,\n{sender['name']}"
 
         if not to or len(to) == 0:
-
-            def callback(followup):
-                if not followup.answer:
-                    return self.prepare_processed(None, self.when, self.body, self.sender)
-                else:
-                    return self.prepare_processed([followup.answer], self.when, self.body, self.sender)
-
-            question = "\nFound no receiver. Please enter the name of the receiver"
-            return StringFollowup(question, callback)
-
+            return self.prompt_receiver()
         elif len(to) > 1:
             raise ToManyReceiversError("Can only handle one (1) receiver at this time")
-
         if not body:
-
-            def callback(followup):
-                return self.prepare_processed(self.to, self.when, followup.answer, self.sender)
-
-            question = "\nFound no message body. What message should be sent"
-            return StringFollowup(question, callback)
+            return self.prompt_body()
 
         parsed_recipients = get_emails(self.to, sender)
         recipients = parsed_recipients["emails"]
@@ -155,6 +140,23 @@ class Send(Module):
         _body = " ".join(body)
 
         return (to, time, _body)
+
+    def prompt_receiver(self):
+        def callback(followup):
+            if not followup.answer:
+                return self.prepare_processed(None, self.when, self.body, self.sender)
+            else:
+                return self.prepare_processed([followup.answer], self.when, self.body, self.sender)
+
+        question = "\nFound no receiver. Please enter the name of the receiver"
+        return StringFollowup(question, callback)
+
+    def prompt_body(self):
+        def callback(followup):
+            return self.prepare_processed(self.to, self.when, followup.answer, self.sender)
+
+        question = "\nFound no message body. What message should be sent"
+        return StringFollowup(question, callback)
 
 
 class ToManyReceiversError(Error):

--- a/lib/utils/ner.py
+++ b/lib/utils/ner.py
@@ -45,7 +45,10 @@ def cross_check_names(tagged, persons) -> list:
     ok = []
 
     for tag in tagged:
-        value, score = fuzzy.extractOne(tag, persons)
-        if score > MIN_SCORE and value not in ok:
-            ok.append(value)
+        try:
+            value, score = fuzzy.extractOne(tag, persons)
+            if score > MIN_SCORE and value not in ok:
+                ok.append(value)
+        except RuntimeError:
+            continue
     return ok


### PR DESCRIPTION
Earlier the followup was handled by the automation modules
themselves, returing only a string for context.

This commit defines a Followup interface, with inherited classes
MultiFollowup, StringFollowup and BooleanFollowup. The attributes
of the different classes differ somewhat, but they all contain
a .question and an .answer. Control can be given back to the
automation module via a .callback().

# Todo in next PR
* Move all print() and input() to the CLI.

# Proposed changes
* Use classes to return instead of strings when doing followup questions.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- Ran all followup questions in all four modules in the CLI. Some were hard to reach, so I did some temporary patching to reach those.

# Related issue
Fixes #158

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
