### PR TITLE
Catch program aborts when preparing tasks, fix invalid ModelPool usage

### DIFF
--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import logging
 import spacy
-import asyncio
 import lib.utils.ner as ner
 
 from lib import Error
@@ -143,12 +142,15 @@ class RemoveSchedule(Module):
 
     def nlp(self, text):
         doc = self.nlp_model(text)
-        ner_model = asyncio.run(self.model_pool.acquire_model("xx_ent_wiki_sm"))
 
         to = []
         when = []
         body = []
-        persons = ner.get_persons(ner_model, text)
+        persons = []
+
+        locked_ner_model = self.model_pool.get_shared_model("xx_ent_wiki_sm")
+        with locked_ner_model:
+            persons = ner.get_persons(locked_ner_model.acquire_model(), text)
 
         for token in doc:
             if token.dep_ == "TO":
@@ -166,7 +168,6 @@ class RemoveSchedule(Module):
         to = ner.cross_check_names(to, persons)
         log.debug("Recipients: %s", ",".join(to))
         _body = " ".join(body)
-        self.model_pool.release_model(ner_model)
 
         return (to, time, _body)
 

--- a/lib/automate/modules/schedule.py
+++ b/lib/automate/modules/schedule.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import lib.utils.tools.time_convert as tc
 import spacy
 import logging
-import asyncio
 import lib.utils.ner as ner
 
 from lib import Error
@@ -127,13 +126,16 @@ class Schedule(Module):
 
     def nlp(self, text):
         doc = self.nlp_model(text)
-        ner_model = asyncio.run(self.model_pool.acquire_model("xx_ent_wiki_sm"))
 
         to = []
         start = []
         end = []
         body = []
-        persons = ner.get_persons(ner_model, text)
+        persons = []
+
+        locked_ner_model = self.model_pool.get_shared_model("xx_ent_wiki_sm")
+        with locked_ner_model:
+            persons = ner.get_persons(locked_ner_model.acquire_model(), text)
 
         for token in doc:
             if token.dep_ == "TO":
@@ -162,7 +164,6 @@ class Schedule(Module):
             end_time = tc.parse_time(end)
 
         _body = " ".join(body)
-        self.model_pool.release_model(ner_model)
 
         return (to, {"start": start_time, "end": end_time}, _body)
 

--- a/lib/cli/cli.py
+++ b/lib/cli/cli.py
@@ -21,9 +21,10 @@ def cli(debug, verbose):
 
     click.secho("\nType any task(s) and the robot will start working on it", bold=True)
     click.secho("(or type 'help' to display all options):", bold=True)
+    suffix = click.style(">>> ", bold=True, fg="bright_cyan")
     try:
         while True:
-            txt = click.prompt("", prompt_suffix="> ").strip()
+            txt = click.prompt("", prompt_suffix=suffix).strip()
 
             if txt == "":
                 continue

--- a/lib/cli/commands.py
+++ b/lib/cli/commands.py
@@ -57,8 +57,8 @@ def commands(arr, selector):
 def help_output():
     dirname = os.path.dirname(__file__)
     filename = os.path.join(dirname, "helpprompt.txt")
-    f = open(filename, "r")
-    print(f.read())
+    with click.open_file(filename, "r") as f:
+        click.echo(f.read())
 
 
 def run_selector(input, selector):
@@ -66,5 +66,8 @@ def run_selector(input, selector):
         responses = selector.run(input)
         for response in responses:
             click.echo(response + "\n")
+    except (KeyboardInterrupt, EOFError):
+        click.echo("Task aborted. \n")
     except Exception as e:
-        print("Failed to execute action.\n", e, file=sys.stderr)
+        click.echo("Failed to execute action.")
+        click.echo(str(e) + "\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 https://github.com/rpa-tomorrow/model-releases/releases/download/en_rpa_simple_reminder-0.0.1/en_rpa_simple_reminder-0.0.1.tar.gz 
 https://github.com/rpa-tomorrow/model-releases/releases/download/en_rpa_simple_email-0.0.1/en_rpa_simple_email-0.0.1.tar.gz
 https://github.com/rpa-tomorrow/model-releases/releases/download/en_rpa_simple-0.0.1/en_rpa_simple-0.0.1.tar.gz
-https://github.com/rpa-tomorrow/model-releases/releases/download/en_rpa_simple_calendar-0.0.3/en_rpa_simple_calendar-0.0.4.tar.gz
+https://github.com/rpa-tomorrow/model-releases/releases/download/en_rpa_simple_calendar-0.0.4/en_rpa_simple_calendar-0.0.4.tar.gz

--- a/tests/selector/use_cases/conftest.py
+++ b/tests/selector/use_cases/conftest.py
@@ -1,8 +1,9 @@
 import pytest
 from datetime import datetime, timedelta
+from lib.automate.google import Google, Calendar
 
 
-class CalendarMock:
+class CalendarMock(Calendar):
     """
     A calendar mock where event creation just returns the parameters of the
     event
@@ -49,7 +50,7 @@ class CalendarNeverBusyMock(CalendarMock):
         return []
 
 
-class GoogleMock:
+class GoogleMock(Google):
     def __init__(self, username):
         self.username = username
 


### PR DESCRIPTION
# Proposed changes
* Catch KeyboardInterrupts from the modules and then continue the program. Lets one abort the task during preparation.
* Fix invalid ModelPool usage in the schedule modules
* Fixes unit tests for removing calendar (cred @hugowangler)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- Prepare an incomplete task, then abort with either `C-c` or `C-d`. Should return to the main program again.

# Related issue
Fixes #155, fixes #171 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
