### PR TITLE
Prompt the user before executing task

### DIFF
--- a/lib/automate/modules/reminder.py
+++ b/lib/automate/modules/reminder.py
@@ -51,6 +51,7 @@ class Reminder(Module):
         if self.nlp_model is None:
             self.nlp_model = spacy.load(nlp_model_names["reminder"])
         to, when, body = self.nlp(text)
+        self.description = None
         return self.prepare_processed(to, when, body, sender)
 
     def prepare_processed(self, _to, when, body, _sender):

--- a/lib/automate/modules/remove_schedule.py
+++ b/lib/automate/modules/remove_schedule.py
@@ -4,7 +4,7 @@ import spacy
 import lib.utils.ner as ner
 
 from lib import Error
-from lib.automate.followup import BooleanFollowup, MultiFollowup
+from lib.automate.followup import MultiFollowup
 from lib.utils import contacts
 from lib.automate.google import Google
 from lib.automate.modules import Module
@@ -55,10 +55,7 @@ class RemoveSchedule(Module):
 
         # if the event has already been found then just prompt the user
         if self.event:
-            start_time = self.event["start"]["dateTime"]
-            start_time = datetime.fromisoformat(start_time)
-            formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
-            self.description = f"\nYou have the event '{self.event['summary']}' scheduled at {formated_time}.\nDo you want to remove it?"
+            self.description = self.get_task_description(self.event)
             return None
 
         # try to fetch the event by the summary
@@ -86,11 +83,7 @@ class RemoveSchedule(Module):
 
         if len(self.events) == 1:
             self.event = self.events[0]
-
-            start_time = self.event["start"]["dateTime"]
-            start_time = datetime.fromisoformat(start_time)
-            formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
-            self.description = f"\nYou have the event '{self.event['summary']}' scheduled at {formated_time}.\nDo you want to remove it?"
+            self.description = self.get_task_description(self.event)
         elif len(self.events) > 1:
             return self.prompt_multiple()
         else:
@@ -149,6 +142,14 @@ class RemoveSchedule(Module):
         _body = " ".join(body)
 
         return (to, time, _body)
+
+    def get_task_description(self, event):
+        start_time = self.event["start"]["dateTime"]
+        start_time = datetime.fromisoformat(start_time)
+        formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
+        return (
+            f"\nYou have the event '{self.event['summary']}' scheduled at {formated_time}.\nDo you want to remove it?"
+        )
 
 
 class NoEventFoundError(Error):

--- a/lib/automate/modules/schedule.py
+++ b/lib/automate/modules/schedule.py
@@ -27,6 +27,8 @@ class Schedule(Module):
         if self.nlp_model is None:
             self.nlp_model = spacy.load(nlp_model_names["schedule"])
         to, when, body = self.nlp(text)
+
+        self.description = ""
         return self.prepare_processed(to, when, body, sender)
 
     def prepare_processed(self, to, when, body, sender):
@@ -67,6 +69,7 @@ class Schedule(Module):
         attendees = [settings["address"]] + attendees
         event = calendar.event(self.when["start"], self.when["end"], attendees, self.body)
         self.event = event
+        self.description = f"The event {self.body} at {self.when['start'].strftime('%H:%M, %A, %d. %B %Y')} was prepared\nDo you want to book it?"
 
         # Check if we are busy
         me_busy = calendar.freebusy(self.when["start"], self.when["end"], ["primary"])

--- a/lib/automate/modules/schedule.py
+++ b/lib/automate/modules/schedule.py
@@ -69,7 +69,10 @@ class Schedule(Module):
         attendees = [settings["address"]] + attendees
         event = calendar.event(self.when["start"], self.when["end"], attendees, self.body)
         self.event = event
-        self.description = f"The event {self.body} at {self.when['start'].strftime('%H:%M, %A, %d. %B %Y')} was prepared\nDo you want to book it?"
+        self.description = (
+            f"The event {self.body} at {self.when['start'].strftime('%H:%M, %A, %d. %B %Y')} "
+            + "was prepared\nDo you want to book it?"
+        )
 
         # Check if we are busy
         me_busy = calendar.freebusy(self.when["start"], self.when["end"], ["primary"])

--- a/lib/automate/modules/update_schedule.py
+++ b/lib/automate/modules/update_schedule.py
@@ -4,7 +4,7 @@ import spacy
 import lib.utils.ner as ner
 
 from lib import Error
-from lib.automate.followup import MultiFollowup, BooleanFollowup
+from lib.automate.followup import MultiFollowup
 from lib.utils import contacts
 from lib.automate.google import Google
 from lib.automate.modules import Module
@@ -55,13 +55,7 @@ class UpdateSchedule(Module):
 
         # if the event has already been found then just prompt the user
         if self.event:
-            start_time = self.event["start"]["dateTime"]
-            start_time = datetime.fromisoformat(start_time)
-            formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
-            self.description = (
-                f"You have the event '{self.event['summary']}' scheduled at {formated_time}.\n"
-                "Do you want to update it?"
-            )
+            self.description = self.get_task_description(self.event)
             return None
 
         # try to fetch the event by the summary
@@ -94,12 +88,7 @@ class UpdateSchedule(Module):
         else:
             raise NoEventFoundError("Could not find an event.")
 
-        start_time = self.event["start"]["dateTime"]
-        start_time = datetime.fromisoformat(start_time)
-        formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
-        self.description = (
-            f"You have the event '{self.event['summary']}' scheduled at {formated_time}.\n" "Do you want to update it?"
-        )
+        self.description = self.get_task_description(self.event)
 
     def prompt_multiple(self):
         def callback(followup):
@@ -174,6 +163,14 @@ class UpdateSchedule(Module):
         _body["new start"] = new_start_time
 
         return (to, start_time, _body)
+
+    def get_task_description(self, event):
+        start_time = self.event["start"]["dateTime"]
+        start_time = datetime.fromisoformat(start_time)
+        formated_time = start_time.strftime("%H:%M, %A, %d. %B %Y")
+        return (
+            f"\nYou have the event '{self.event['summary']}' scheduled at {formated_time}.\nDo you want to remove it?"
+        )
 
 
 class NoEventFoundError(Error):

--- a/lib/selector/selector.py
+++ b/lib/selector/selector.py
@@ -102,7 +102,7 @@ class ModuleSelector:
                         responses.append("Task aborted.")
 
                 # prompt the user with the description of the task before executing it
-                if task.description:
+                if task.description is not None:
                     followup = BooleanFollowup(task.description, callback, default_answer=False)
                     followup.handle_cli()
                 else:

--- a/lib/utils/contacts.py
+++ b/lib/utils/contacts.py
@@ -110,7 +110,12 @@ def prompt_contact_choice(name: str, candidates, module) -> str:
                 raise NoContactFoundError("No contact with name " + name + " was found")
 
         followup_str = f"Found multiple contacts with the name {name}"
-        return MultiFollowup(followup_str, candidates, callback, True)
+        # the  MultiFollowup takes a list of tuples (the options variable) where the first element in
+        # the tuple is the actuall choice to be made, in this case the email of the wanted contact
+        # the second element in the tuple is what's to be outputted to the screen,
+        # in this case it should be "Contact Name - Contact Email" to give enough information to the user
+        options = list(map(lambda c: (c[1], c[0] + " - " + c[1]), candidates))
+        return MultiFollowup(followup_str, options, callback, True)
 
 
 class NoContactFoundError(Error):

--- a/tests/selector/conftest.py
+++ b/tests/selector/conftest.py
@@ -38,6 +38,8 @@ class MockTask:
     A mocked task which has an execute function that just returns a response
     """
 
+    description = None
+
     def execute(self):
         """ The mocked response """
         return "this is a response"

--- a/tests/selector/use_cases/conftest.py
+++ b/tests/selector/use_cases/conftest.py
@@ -27,14 +27,14 @@ class CalendarMock(Calendar):
             {
                 "summary": "test",
                 "attendees": [{"email": "niklas@email.com"}],
-                "start": {"date": start_time_1.isoformat(), "dateTime": start_time_1.time()},
-                "end": {"date": end_time_1.isoformat(), "dateTime": end_time_1.time()},
+                "start": {"date": start_time_1.isoformat(), "dateTime": start_time_1.isoformat()},
+                "end": {"date": end_time_1.isoformat(), "dateTime": end_time_1.isoformat()},
             },
             {
                 "summary": "another one",
                 "attendees": [{"email": "hugo@email.com"}],
-                "start": {"date": start_time_2.isoformat(), "dateTime": start_time_2.time()},
-                "end": {"date": end_time_2.isoformat(), "dateTime": end_time_2.time()},
+                "start": {"date": start_time_2.isoformat(), "dateTime": start_time_2.isoformat()},
+                "end": {"date": end_time_2.isoformat(), "dateTime": end_time_2.isoformat()},
             },
         ]
 
@@ -71,8 +71,13 @@ def calendar_not_busy(monkeypatch):
     def mock_execute(self):
         return self.event
 
+    def mock_handle_cli(self):
+        self.answer = "y"
+        self.callback()
+
     monkeypatch.setattr("lib.automate.modules.schedule.Google", GoogleNeverBusyMock)
     monkeypatch.setattr("lib.automate.modules.schedule.Schedule.execute", mock_execute)
+    monkeypatch.setattr("lib.automate.followup.BooleanFollowup.handle_cli", mock_handle_cli)
 
 
 @pytest.fixture
@@ -85,7 +90,12 @@ def send_email(monkeypatch):
     def mock_send_email(self, settings, receiver, subject, content):
         return {"settings": settings, "receiver": receiver, "subject": subject, "content": content}
 
+    def mock_handle_cli(self):
+        self.answer = "y"
+        self.callback()
+
     monkeypatch.setattr("lib.automate.modules.send.Send.send_email", mock_send_email)
+    monkeypatch.setattr("lib.automate.followup.BooleanFollowup.handle_cli", mock_handle_cli)
 
 
 @pytest.fixture
@@ -96,14 +106,12 @@ def calendar_with_events(monkeypatch):
     get_events.
     """
 
-    def mock_prompt_remove_event(self):
-        """ Dont ask user for confirmation to delete during test """
-        pass
+    def mock_handle_cli(self):
+        self.answer = "y"
+        self.callback()
 
     monkeypatch.setattr("lib.automate.modules.remove_schedule.Google", GoogleMock)
-    monkeypatch.setattr(
-        "lib.automate.modules.remove_schedule.RemoveSchedule.prompt_remove_event", mock_prompt_remove_event
-    )
+    monkeypatch.setattr("lib.automate.followup.BooleanFollowup.handle_cli", mock_handle_cli)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Proposed changes
* Before executing a task the user gets prompted with a small description of what task has been processed
* The user gets to choose if the task should be executed or aborted
* Because a Reminder is a small local task that does not carry any side effects in case something is processed wrong it does not require a prompt 
* Update unit tests to accommodate these changes

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- Run the CLI, try out each of the modules
    - Send email and create/remove calendar should prompt before execution
    - Reminders should not prompt before execution

# Related issue
Fixes #159 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
