### PR TITLE
Add missing settings and validation of fields to GUI

### DIFF
--- a/config/editor.yaml
+++ b/config/editor.yaml
@@ -1,3 +1,3 @@
-theme: dark-theme
 font-family: Roboto, Segoe UI, Arial
-font-size: 12pt
+font-size: '12'
+theme: dark-theme

--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -63,7 +63,7 @@ class ContentFrame(QtWidgets.QFrame):
         self.save_view = FileView(main_window, self.main_window.model)
         self.load_view = FileView(main_window, self.main_window.model)
         self.play_view = PlayView(main_window, self.design_view.process_editor)
-        self.settings_view = SettingsView()
+        self.settings_view = SettingsView(main_window)
         self.info_view = QtWidgets.QFrame()
 
         self.layout.addWidget(self.design_view)
@@ -160,7 +160,7 @@ def initialize_app():
     if SETTINGS["editor"]["font-family"]:
         font_family = SETTINGS["editor"]["font-family"]
     if SETTINGS["editor"]["font-size"]:
-        font_size = SETTINGS["editor"]["font-size"]
+        font_size = SETTINGS["editor"]["font-size"] + "pt"
 
     stylesheet = (
         """

--- a/src/main/python/settings_view.py
+++ b/src/main/python/settings_view.py
@@ -1,13 +1,53 @@
-import PyQt5.QtWidgets as QtWidgets
+import os
 
-from lib.settings import SETTINGS
+import PyQt5.QtWidgets as QtWidgets
+from PyQt5.QtCore import QRegExp, pyqtSlot
+from PyQt5.QtGui import QRegExpValidator, QValidator
+
+from lib.settings import SETTINGS, get_language_versions, get_model_languages, update_settings
+
+VALID = 2  # value of state enum representing valid state after validation
+EMAIL_REGEX = "^([a-zA-Z0-9]+[\\._-]?[a-zA-Z0-9]+)[@](\\w+[.])+\\w{2,3}$"
+
+
+class InputValidator(QRegExpValidator):
+    """
+    A custom validator class that will set mark the parent object as invalid if
+    the validator fails.
+    """
+
+    def __init__(self, *args, allow_empty=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.allow_empty = allow_empty
+
+    def validate(self, text: str, pos: int):
+        state, text, pos = super(InputValidator, self).validate(text, pos)
+        selector = {
+            QValidator.Invalid: "invalid",
+            QValidator.Intermediate: "intermediate",
+            QValidator.Acceptable: "acceptable",
+        }[state]
+
+        if selector == "invalid" or (not self.allow_empty and selector == "intermediate"):
+            self.parent().setProperty("invalid", True)
+        else:
+            self.parent().setProperty("invalid", False)
+
+        self.parent().setStyleSheet("/**/")  # Updates the style of parent
+        return state, text, pos
 
 
 class SettingsView(QtWidgets.QWidget):
-    def __init__(self, *args, **kwargs):
+    # Dict containing the fields which are not allowed to be submitted empty
+    empty_fields = {"name": False}
+
+    def __init__(self, main_window, *args, **kwargs):
         super(SettingsView, self).__init__(*args, **kwargs)
+        self.main_window = main_window
         layout = QtWidgets.QGridLayout()
         layout.setVerticalSpacing(8)
+
+        self.initial_state = SETTINGS  # store the settings to restore it if needed
 
         self.title = QtWidgets.QLabel("Settings")
         self.title.setObjectName("viewTitle")
@@ -16,23 +56,153 @@ class SettingsView(QtWidgets.QWidget):
         row = 0
         layout.addWidget(self.title, row, 0)
 
+        # Editor settings
+        row += 1
+        self.editor_title = QtWidgets.QLabel("Editor")
+        self.editor_title.setObjectName("settingsSectionTitle")
+        layout.addWidget(self.editor_title, row, 0)
+
         row += 1
         self.theme = QtWidgets.QComboBox()
         self.theme.addItem("Light Theme", "light-theme")
         self.theme.addItem("Dark Theme", "dark-theme")
         self.theme.setCurrentIndex(self.theme.findData(SETTINGS["editor"]["theme"]))
-        layout.addWidget(QtWidgets.QLabel("Editor theme"), row, 0)
+        layout.addWidget(QtWidgets.QLabel("Theme"), row, 0)
         layout.addWidget(self.theme, row, 1)
 
         row += 1
         self.font_family = QtWidgets.QLineEdit(SETTINGS["editor"]["font-family"])
-        layout.addWidget(QtWidgets.QLabel("Editor font"), row, 0)
+        layout.addWidget(QtWidgets.QLabel("Font"), row, 0)
         layout.addWidget(self.font_family, row, 1)
 
         row += 1
         self.font_size = QtWidgets.QLineEdit(SETTINGS["editor"]["font-size"])
-        layout.addWidget(QtWidgets.QLabel("Editor font size"), row, 0)
+        layout.addWidget(QtWidgets.QLabel("Font size"), row, 0)
+        self.font_size_validator = InputValidator(QRegExp("^[0-9]+$"), self.font_size)
+        self.font_size.setValidator(self.font_size_validator)
         layout.addWidget(self.font_size, row, 1)
+
+        # Meeting settings
+        row += 1
+        self.meetings_title = QtWidgets.QLabel("Meetings")
+        self.meetings_title.setObjectName("settingsSectionTitle")
+        layout.addWidget(self.meetings_title, row, 0)
+
+        row += 1
+        self.standard_duration = QtWidgets.QLineEdit(str(SETTINGS["meeting"]["standard_duration"]))
+        self.std_dur_validator = InputValidator(QRegExp("^[0-9]+$"), self.standard_duration)
+        self.standard_duration.setValidator(self.std_dur_validator)
+        layout.addWidget(QtWidgets.QLabel("Standard duration (min)"), row, 0)
+        layout.addWidget(self.standard_duration, row, 1)
+
+        # User settings section
+        row += 1
+        self.email_title = QtWidgets.QLabel("User")
+        self.email_title.setObjectName("settingsSectionTitle")
+        layout.addWidget(self.email_title, row, 0)
+
+        # Name
+        row += 1
+        self.name = QtWidgets.QLineEdit(str(SETTINGS["user"]["name"]))
+        self.name.textChanged.connect(self.is_empty)
+        layout.addWidget(QtWidgets.QLabel("Name"), row, 0)
+        layout.addWidget(self.name, row, 1)
+
+        # Email
+        row += 1
+        self.email_address = QtWidgets.QLineEdit(str(SETTINGS["user"]["email"]["address"]))
+        self.email_validator = InputValidator(QRegExp(EMAIL_REGEX), self.email_address)
+        self.email_address.setValidator(self.email_validator)
+        layout.addWidget(QtWidgets.QLabel("Email"), row, 0)
+        layout.addWidget(self.email_address, row, 1)
+
+        # Email password
+        row += 1
+        self.email_password = QtWidgets.QLineEdit(
+            str(SETTINGS["user"]["email"]["password"] if SETTINGS["user"]["email"]["password"] is not None else "")
+        )
+        self.email_password.setEchoMode(QtWidgets.QLineEdit.Password)
+        layout.addWidget(QtWidgets.QLabel("Password"), row, 0)
+        layout.addWidget(self.email_password, row, 1)
+
+        # SMTP server section
+        row += 1
+        self.smtp_title = QtWidgets.QLabel("SMTP server")
+        self.smtp_title.setObjectName("settingsSectionTitle")
+        layout.addWidget(self.smtp_title, row, 0)
+
+        # SMTP username (email)
+        row += 1
+        conf_username = SETTINGS["user"]["email"]["username"]
+        self.smtp_username = QtWidgets.QLineEdit(str(conf_username))
+        layout.addWidget(QtWidgets.QLabel("Username"), row, 0)
+        layout.addWidget(self.smtp_username, row, 1)
+
+        # SMTP host
+        row += 1
+        self.smtp_host = QtWidgets.QLineEdit(str(SETTINGS["user"]["email"]["host"]))
+        layout.addWidget(QtWidgets.QLabel("Host"), row, 0)
+        layout.addWidget(self.smtp_host, row, 1)
+
+        # SMTP port
+        row += 1
+        self.smtp_port = QtWidgets.QLineEdit(str(SETTINGS["user"]["email"]["port"]))
+        self.port_validator = InputValidator(QRegExp("^[0-9]+$"), self.smtp_port, allow_empty=True)
+        self.smtp_port.setValidator(self.port_validator)
+        layout.addWidget(QtWidgets.QLabel("Port"), row, 0)
+        layout.addWidget(self.smtp_port, row, 1)
+
+        # SMTP SSL
+        row += 1
+        self.smtp_ssl = QtWidgets.QCheckBox()
+        if SETTINGS["user"]["email"]["ssl"]:
+            self.smtp_ssl.setChecked(True)
+        layout.addWidget(QtWidgets.QLabel("SSL"), row, 0)
+        layout.addWidget(self.smtp_ssl, row, 1)
+
+        # Model config
+        row += 1
+        self.model_title = QtWidgets.QLabel("Model")
+        self.model_title.setObjectName("settingsSectionTitle")
+        layout.addWidget(self.model_title, row, 0)
+
+        # Model language selection
+        row += 1
+        self.model_language = QtWidgets.QComboBox()
+        lang_options = get_model_languages()
+        for opt in lang_options:
+            self.model_language.addItem(opt, opt)
+        self.model_language.setCurrentIndex(self.model_language.findData(SETTINGS["user"]["language"]))
+        self.model_language.currentTextChanged.connect(self.language_changed)
+        layout.addWidget(QtWidgets.QLabel("Language"), row, 0)
+        layout.addWidget(self.model_language, row, 1)
+
+        # Model language versions
+        row += 1
+        self.model_lang_version = QtWidgets.QComboBox()
+        version_options = get_language_versions(SETTINGS["user"]["language"])
+        for opt in version_options:
+            self.model_lang_version.addItem(opt, opt)
+        self.model_lang_version.setCurrentIndex(self.model_lang_version.findData(SETTINGS["user"]["language_version"]))
+        layout.addWidget(QtWidgets.QLabel("Version"), row, 0)
+        layout.addWidget(self.model_lang_version, row, 1)
+
+        # empty row
+        row += 1
+        layout.addWidget(QtWidgets.QLabel(""), row, 0)
+
+        # Button row
+        # Update and restore
+        row += 1
+        button_row = QtWidgets.QGridLayout()
+        button_row.setHorizontalSpacing(10)
+        submit_button = QtWidgets.QPushButton("Update")
+        submit_button.clicked.connect(self.submit_on_click)
+        restore_button = QtWidgets.QPushButton("Restore")
+        restore_button.clicked.connect(self.restore_on_click)
+        button_row.addWidget(submit_button, 0, 1)
+        button_row.addWidget(restore_button, 0, 0)
+        layout.addLayout(button_row, row, 1)
 
         # If needed make space below empty
         row += 1
@@ -40,3 +210,112 @@ class SettingsView(QtWidgets.QWidget):
         layout.setRowStretch(row, 1)
 
         self.setLayout(layout)
+
+    @pyqtSlot()
+    def language_changed(self):
+        """
+        Update the version options whenever the user selects another language
+        """
+        version_options = get_language_versions(self.model_language.currentData())
+        self.model_lang_version.clear()
+        for opt in version_options:
+            self.model_lang_version.addItem(opt, opt)
+        self.model_lang_version.setCurrentIndex(0)
+
+    @pyqtSlot()
+    def is_empty(self):
+        """ Checks if the text in the widget is empty and updates the empty state """
+        if self.sender() == self.name:
+            if self.name.text() == "":
+                self.empty_fields["name"] = True
+                self.name.setProperty("invalid", True)
+            else:
+                self.empty_fields["name"] = False
+                self.name.setProperty("invalid", False)
+            self.name.setStyleSheet("/**/")
+
+    @pyqtSlot()
+    def restore_on_click(self):
+        """ Restores the users settings to the initial values loaded from config """
+        # Editor
+        self.theme.setCurrentIndex(self.theme.findData(self.initial_state["editor"]["theme"]))
+        self.font_family.setText(self.initial_state["editor"]["font-family"])
+        self.font_size.setText(self.initial_state["editor"]["font-size"])
+
+        # Meetings
+        self.standard_duration.setText(str(self.initial_state["meeting"]["standard_duration"]))
+
+        # User
+        self.name.setText(self.initial_state["user"]["name"])
+        self.email_address.setText(self.initial_state["user"]["email"]["address"])
+        self.email_password.setText(self.initial_state["user"]["email"]["password"])
+
+        # SMTP
+        self.smtp_username.setText(self.initial_state["user"]["email"]["username"])
+        self.smtp_host.setText(self.initial_state["user"]["email"]["host"])
+        self.smtp_port.setText(str(self.initial_state["user"]["email"]["port"]))
+        self.smtp_ssl.setChecked(self.initial_state["user"]["email"]["ssl"])
+
+        # Model
+        self.model_language.setCurrentIndex(self.model_language.findData(self.initial_state["user"]["language"]))
+        self.model_lang_version.setCurrentIndex(
+            self.model_lang_version.findData(self.initial_state["user"]["language_version"])
+        )
+
+        self.main_window.set_info_message("Restored settings.")
+
+    def valid_fields(self):
+        """ Returns a boolean indicating if all the settings are valid """
+        form_states = []
+        state, _, _ = self.std_dur_validator.validate(self.standard_duration.text(), 0)
+        form_states.append(state)
+        state, _, _ = self.font_size_validator.validate(self.font_size.text(), 0)
+        form_states.append(state)
+        state, _, _ = self.email_validator.validate(self.email_address.text(), 0)
+        form_states.append(state)
+        state, _, _ = self.port_validator.validate(self.smtp_port.text(), 0)
+        form_states.append(state)
+
+        # If any of the settings contain invalid input or are empty dont update
+        # settings
+        invalid_form_states = [state for state in form_states if state != VALID]
+        if len(invalid_form_states) or True in self.empty_fields.values():
+            return False
+
+        return True
+
+    @pyqtSlot()
+    def submit_on_click(self):
+        """
+        Update the users config files if all the settings are valid and the
+        required fields are not empty.
+        """
+
+        if not self.valid_fields():
+            self.main_window.set_info_message("Failed to update settings. Some fields are either invalid or empty.")
+            return
+
+        # Editor
+        SETTINGS["editor"]["theme"] = self.theme.currentData()
+        SETTINGS["editor"]["font-family"] = self.font_family.text()
+        SETTINGS["editor"]["font-size"] = self.font_size.text()
+        update_settings(os.path.abspath("config/editor"), SETTINGS["editor"])
+
+        # Meetings
+        SETTINGS["meeting"]["standard_duration"] = int(self.standard_duration.text())
+        update_settings(os.path.abspath("config/meetings"), SETTINGS["meeting"])
+
+        # User
+        SETTINGS["user"]["name"] = self.name.text()
+        SETTINGS["user"]["email"] = {
+            "address": self.email_address.text(),
+            "host": self.smtp_host.text(),
+            "password": self.email_password.text() if self.email_password.text() != "" else None,
+            "port": int(self.smtp_port.text()),
+            "ssl": self.smtp_ssl.isChecked(),
+            "username": self.smtp_username.text(),
+        }
+        SETTINGS["user"]["language"] = self.model_language.currentData()
+        SETTINGS["user"]["language_version"] = self.model_lang_version.currentData()
+        update_settings(os.path.abspath("config/user"), SETTINGS["user"])
+        self.main_window.set_info_message("Updated settings.")

--- a/src/main/qss/base.qss
+++ b/src/main/qss/base.qss
@@ -3,6 +3,11 @@ QLabel#viewTitle {
     color: dodgerblue;
 }
 
+QLabel#settingsSectionTitle {
+    font-size: 20pt;
+    color: dodgerblue;
+}
+
 QToolButton {
     font-size: 24px;
     font-family: FontAwesome;
@@ -91,6 +96,14 @@ QLineEdit {
     padding-top: 4px;
     padding-bottom: 4px;
     padding-right: 4px
+}
+
+QLineEdit[invalid="true"] {
+    border: 1px solid red;
+}
+
+QLineEdit[invalid="false"] {
+    border: none;
 }
 
 QComboBox {


### PR DESCRIPTION
# Proposed changes
- Added all of the settings required to use the program
- Added validation to most of the settings fields, this includes
  - Editor
    - font-size: Not empty and only numbers allowed
  - Meetings
    - standard duration: Not empty and only numbers allowed
  - User
    - name: Not empty
    - email: Not empty and only valid emails allowed
- Added red outline to any invalid fields which will be updated every time the input is changed
- Added restore and update buttons
  - Restore will revert all fields to the initial settings.
  - Update will update the settings in the different config files. This will not be done if anything is invalid/missing.

Also, the password field will not show the password (dots). The user is
also only allowed to select the model languages and versions
defined in `./config/nlp_models.yaml`.

Decided to not validate any SMTP settings so that they can be left empty, since I felt that every user will not use/setup SMTP.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- Change all the settings and check in the corresponding config files that the values has been updated accordingly.
- Added dummy languages with different versions to `./config/nlp_models.yaml` and tested that the list of languages is updated. Whenever you change language the version list should also be updated to show the new language's versions.

# Related issue
Fixes #137 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
