### PR TITLE
Fix single contact followup

### DIFF
--- a/lib/utils/contacts.py
+++ b/lib/utils/contacts.py
@@ -88,8 +88,8 @@ def prompt_contact_choice(name: str, candidates, module) -> str:
 
         def callback(followup):
             if followup.answer is not None:
-                module.to.remove(c_name)  # update to so recursive call continues resolving new attendees
-                module.to.append(candidates[followup.answer][1])  # add email of chosen attendee
+                module.to.remove(name)  # update to so recursive call continues resolving new attendees
+                module.to.append(candidates[0][1])  # add email of chosen attendee
                 return module.prepare_processed(module.to, module.when, module.body, module.sender)
             else:
                 raise NoContactFoundError("No contact with name " + name + " was found")


### PR DESCRIPTION
# Proposed changes
* Correctly update the `to` attribute of the schedule module when the user is prompted to confirm single contact followup

This was actually not a problem with Google contacts, I think we just forgot to test how we handle single candidate followups after the followup improvements. IIRC this only occurs when the specified contact is a google contact since we will automatically resolve the contact if it only has a single match in the local contact book.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- using input: `schedule a meeting with <Name of google contact with unique name> at 17:00 about test1337`

# Related issue
Fixes #180 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
