### PR TITLE
Remove the user from being a guest participant in its own event

### DIFF
--- a/lib/automate/modules/schedule.py
+++ b/lib/automate/modules/schedule.py
@@ -66,7 +66,6 @@ class Schedule(Module):
             self.unknown_attendee = name
             return self.prompt_unknown_contact(name)
 
-        attendees = [settings["address"]] + attendees
         event = calendar.event(self.when["start"], self.when["end"], attendees, self.body)
         self.event = event
         self.description = (


### PR DESCRIPTION
# Proposed changes
* Remove the user as a guest participant of its own event

# How Has This Been Tested?
- schedule an event with a participant, check in the calendar that the intended participant is the only guest participant in the event 

# Related issue
Fixes #184 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
