### PR TITLE
 Fix NER bug where certain names are seen as words

### DIFF
--- a/lib/utils/ner.py
+++ b/lib/utils/ner.py
@@ -49,6 +49,11 @@ def cross_check_names(tagged, persons) -> list:
             value, score = fuzzy.extractOne(tag, persons)
             if score > MIN_SCORE and value not in ok:
                 ok.append(value)
-        except RuntimeError:
+        except Exception:
             continue
+
+    for tag in tagged:
+        if not any(tag in name for name in ok):
+            ok.append(tag)
+
     return ok

--- a/tests/utils/ner/test_cross_check.py
+++ b/tests/utils/ner/test_cross_check.py
@@ -1,0 +1,36 @@
+import lib.utils.ner as ner
+
+
+class TestCrossCheck:
+    def test_full_name_returned(self):
+        """
+        Test that the tags and corresponding full name
+        returns the full name when cross checking.
+        """
+        tags = ["mark", "anderson"]
+        persons = ["mark anderson"]
+        cc = ner.cross_check_names(tags, persons)
+
+        assert persons == cc
+
+    def test_same_input_same_output(self):
+        """
+        Test that if tags and persons are the same, cross
+        checking should also return the same output.
+        """
+        tags = ["mark", "evert", "reggie"]
+        cc = ner.cross_check_names(tags, tags)
+
+        assert cc == tags
+
+    def test_missing_tag(self):
+        """
+        Test that when names are missing in persons that are found in
+        tags, the cross check should append the missing tags to persons.
+        """
+        tags = ["mark", "anderson", "evert"]
+        persons = ["mark anderson"]
+        expected = ["mark anderson", "evert"]
+        cc = ner.cross_check_names(tags, persons)
+
+        assert cc == expected


### PR DESCRIPTION
# Proposed changes
* When comparing our models' tagged names with spacy's recognized names, our cross checker will append the missing tags if they are not found in the recognized names list

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- Implemented unit tests for the weird cases names are not found
- Try to send an email to `Mark` and check with debug output that `mark` is a recipient

# Related issue
Fixes #196 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
