### PR TITLE
Fix handling of answer on single contact followup

### DIFF
--- a/lib/utils/contacts.py
+++ b/lib/utils/contacts.py
@@ -89,7 +89,8 @@ def prompt_contact_choice(name: str, candidates, module) -> str:
         def callback(followup):
             if followup.answer is not None:
                 module.to.remove(name)  # update to so recursive call continues resolving new attendees
-                module.to.append(candidates[0][1])  # add email of chosen attendee
+                if followup.answer is True:
+                    module.to.append(candidates[0][1])  # add email of chosen attendee
                 return module.prepare_processed(module.to, module.when, module.body, module.sender)
             else:
                 raise NoContactFoundError("No contact with name " + name + " was found")


### PR DESCRIPTION
# Proposed changes
* When there is only one contact the user has to confirm e.g. a google
contact found, the users answer to Y/n will now be taken into account
and not use the contact if the answer is no.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- send an email to GOOGLE CONTACT, respond with no should remove the contact as a recepient
- same but with schedule
- same as the above tests but responding with yes should add them as a receiver 

# Related issue
Fixes #198 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
