### PR TITLE
Rename substorm-nlp to rpa-tomorrow

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           # $CONDA is an environment variable pointing to the root of the miniconda directory
-          $CONDA/bin/conda env update --file substorm-nlp.yml --name base
+          $CONDA/bin/conda env update --file rpa-tomorrow.yml --name base
       - name: Install models for tests
         run: |
           $CONDA/bin/python -m spacy download xx_ent_wiki_sm

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # RPA Tomorrow - process tasks from natural text
 
 [![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg)](https://www.python.org/)
-[![GitHub release](https://img.shields.io/github/release/rpa-tomorrow/substorm-nlp.svg)](https://github.com/rpa-tomorrow/substorm-nlp/releases/)
-<a href="https://github.com/rpa-tomorrow/substorm-action/actions"><img alt="Actions Status" src="https://github.com/rpa-tomorrow/substorm-nlp/workflows/CI/badge.svg"></a>
-<a href="https://github.com/rpa-tomorrow/substorm-nlp/blob/master/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
+[![GitHub release](https://img.shields.io/github/release/rpa-tomorrow/rpa-tomorrow.svg)](https://github.com/rpa-tomorrow/rpa-tomorrow/releases/)
+<a href="https://github.com/rpa-tomorrow/rpa-tomorrow/actions"><img alt="Actions Status" src="https://github.com/rpa-tomorrow/rpa-tomorrow/workflows/CI/badge.svg"></a>
+<a href="https://github.com/rpa-tomorrow/rpa-tomorrow/blob/master/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 
 </p>
@@ -50,23 +50,23 @@ that will be used for deriving the key for encryption and decryption of the pass
 required for authentication against the SMTP server.
 
 To create and activate the project environment the included setup script can be used
-
+(Linux only)
 ```bash
-$ source substorm.sh
+$ source init_env.sh
 ```
 
 Otherwise you can do it manually
 
 ```bash
 # Create environment
-$ conda env create -f substorm-nlp.yml
+$ conda env create -f rpa-tomorrow.yml
 # Install RPA models
 $ pip install -r requirements.txt
 # Activate environment
-$ conda activate substorm-nlp
+$ conda activate rpa-tomorrow
 ```
 
-**NOTE!** If you're on Windows, replace all `substorm-nlp` with `substorm-nlp-win` above.
+**NOTE!** If you're on Windows, replace all `rpa-tomorrow` with `rpa-tomorrow-win` above.
 
 ### Advanced setup
 

--- a/docs/google_auth_setup.md
+++ b/docs/google_auth_setup.md
@@ -15,7 +15,7 @@ https://www.googleapis.com/auth/contacts.other.readonly
 https://www.googleapis.com/auth/directory.readonly
 ```
 
-After that download the credentials and put it in `substorm-nlp/` directory, also name it `client_secret.json`.
+After that download the credentials and put it in the project root directory, also name it `client_secret.json`.
 
 Now the schedule module should work and any created meetings should show up in the calendar of the account you created the credentials for.
 

--- a/init_env.sh
+++ b/init_env.sh
@@ -7,7 +7,7 @@ then
     conda env create -f rpa-tomorrow.yml
 fi
 
-echo "activate conda RPA Tomorrow env..."
+echo "activate conda rpa-tomorrow env..."
 source ~/anaconda3/etc/profile.d/conda.sh 
 conda activate rpa-tomorrow 
 

--- a/init_env.sh
+++ b/init_env.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-MULTILINE1=$(conda env list | grep -F substorm-nlp)
+MULTILINE1=$(conda env list | grep -F rpa-tomorrow)
 
 if [ "$MULTILINE1" = "" ]
 then
     echo "no conda env found, creating env..."
-    conda env create -f substorm-nlp.yml
+    conda env create -f rpa-tomorrow.yml
 fi
 
-echo "activate conda substorm-nlp env..."
+echo "activate conda RPA Tomorrow env..."
 source ~/anaconda3/etc/profile.d/conda.sh 
-conda activate substorm-nlp
+conda activate rpa-tomorrow 
 
 MULTILINE2=$(pip list | grep -F en-rpa-simple)
 

--- a/rpa-tomorrow-win.yml
+++ b/rpa-tomorrow-win.yml
@@ -1,4 +1,4 @@
-name: substorm-nlp-win
+name: rpa-tomorrow-win
 channels:
   - conda-forge
   - defaults

--- a/rpa-tomorrow.yml
+++ b/rpa-tomorrow.yml
@@ -1,4 +1,4 @@
-name: substorm-nlp
+name: rpa-tomorrow 
 channels:
   - conda-forge
   - defaults


### PR DESCRIPTION
# Proposed changes
* Rename all occurrences of `substorm-nlp` to `rpa-tomorrow`
    * Will rename on Github if this PR is approved

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- Create a new environment with the new name (e.g. run the init file)

# Related issue
Fixes #204 

# Checkboxes
- [x] I have run the unit tests with `pytest`
- [x] I formatted the changes with `./scripts/formatter.sh`
